### PR TITLE
Implement tipping policy components

### DIFF
--- a/tipical-frontend/src/components/tipping/TippingPolicyDisplay.tsx
+++ b/tipical-frontend/src/components/tipping/TippingPolicyDisplay.tsx
@@ -1,0 +1,57 @@
+import { useTippingData } from '../../hooks';
+import type { TippingPolicy as TippingPolicyType } from '../../types';
+import { TippingPolicy } from '../../types';
+
+const POLICY_LABELS: Record<TippingPolicyType, string> = {
+  [TippingPolicy.NoTips]: 'No Tips',
+  [TippingPolicy.TipsExcludeTax]: 'Tips on Subtotal',
+  [TippingPolicy.TipsIncludeTax]: 'Tips on Total',
+};
+
+const POLICY_BADGE_STYLES: Record<TippingPolicyType, string> = {
+  [TippingPolicy.NoTips]: 'bg-green-100 text-green-800',
+  [TippingPolicy.TipsExcludeTax]: 'bg-yellow-100 text-yellow-800',
+  [TippingPolicy.TipsIncludeTax]: 'bg-red-100 text-red-800',
+};
+
+interface TippingPolicyDisplayProps {
+  businessId: string;
+}
+
+export function TippingPolicyDisplay({ businessId }: TippingPolicyDisplayProps) {
+  const { votes, isLoading, error } = useTippingData(businessId);
+
+  if (isLoading) {
+    return <div className="animate-pulse h-12 bg-gray-100 rounded-lg" />;
+  }
+
+  if (error) {
+    return <p className="text-sm text-red-600">Failed to load tipping data.</p>;
+  }
+
+  if (!votes || votes.totalVotes === 0 || votes.winningPolicy === undefined) {
+    return (
+      <div className="text-center py-3">
+        <p className="text-sm text-gray-500">No votes yet.</p>
+        <p className="text-xs text-gray-400 mt-1">Be the first to share the tipping policy!</p>
+      </div>
+    );
+  }
+
+  const leadingCount = votes.winningPolicyVoteCount ?? votes.votesByPolicy[votes.winningPolicy];
+  const peopleStr = votes.totalVotes === 1 ? 'person says' : 'people say';
+
+  return (
+    <div className="space-y-1.5">
+      <span
+        className={`inline-block px-3 py-1 rounded-full text-sm font-semibold ${POLICY_BADGE_STYLES[votes.winningPolicy]}`}
+      >
+        {POLICY_LABELS[votes.winningPolicy]}
+      </span>
+      <p className="text-sm text-gray-600">
+        {leadingCount} of {votes.totalVotes} {peopleStr}:{' '}
+        <span className="font-medium">{POLICY_LABELS[votes.winningPolicy]}</span>
+      </p>
+    </div>
+  );
+}

--- a/tipical-frontend/src/components/tipping/TippingPolicySelector.tsx
+++ b/tipical-frontend/src/components/tipping/TippingPolicySelector.tsx
@@ -1,0 +1,85 @@
+import { useAuthStore } from '../../stores/authStore';
+import { useUIStore } from '../../stores/uiStore';
+import { useTippingData } from '../../hooks';
+import type { TippingPolicy as TippingPolicyType } from '../../types';
+import { TippingPolicy } from '../../types';
+
+interface PolicyOption {
+  policy: TippingPolicyType;
+  label: string;
+  selectedStyles: string;
+  idleStyles: string;
+}
+
+const POLICY_OPTIONS: PolicyOption[] = [
+  {
+    policy: TippingPolicy.NoTips,
+    label: 'No Tips',
+    selectedStyles: 'bg-green-600 text-white border-green-600',
+    idleStyles: 'bg-white text-green-700 border-green-300 hover:bg-green-50',
+  },
+  {
+    policy: TippingPolicy.TipsExcludeTax,
+    label: 'Tips on Subtotal',
+    selectedStyles: 'bg-yellow-500 text-white border-yellow-500',
+    idleStyles: 'bg-white text-yellow-700 border-yellow-300 hover:bg-yellow-50',
+  },
+  {
+    policy: TippingPolicy.TipsIncludeTax,
+    label: 'Tips on Total',
+    selectedStyles: 'bg-red-600 text-white border-red-600',
+    idleStyles: 'bg-white text-red-700 border-red-300 hover:bg-red-50',
+  },
+];
+
+interface TippingPolicySelectorProps {
+  businessId: string;
+}
+
+export function TippingPolicySelector({ businessId }: TippingPolicySelectorProps) {
+  const isAuthenticated = useAuthStore(s => s.isAuthenticated());
+  const setShowAuthModal = useUIStore(s => s.setShowAuthModal);
+  const { userVote, submitVote, isSubmitting, submitError } = useTippingData(businessId);
+
+  const handleVote = (policy: TippingPolicyType) => {
+    if (!isAuthenticated) {
+      setShowAuthModal(true);
+      return;
+    }
+    submitVote(policy);
+  };
+
+  return (
+    <div className="space-y-2">
+      <p className="text-sm font-medium text-gray-700">What's the tipping policy here?</p>
+      <div className="flex flex-col gap-2">
+        {POLICY_OPTIONS.map(({ policy, label, selectedStyles, idleStyles }) => {
+          const isSelected = userVote?.tippingPolicy === policy;
+          return (
+            <button
+              key={policy}
+              onClick={() => handleVote(policy)}
+              disabled={isSubmitting}
+              aria-pressed={isSelected}
+              className={`
+                w-full px-4 py-2.5 rounded-lg border text-sm font-medium
+                transition-colors focus:outline-none focus:ring-2 focus:ring-offset-1
+                disabled:cursor-not-allowed disabled:opacity-60
+                ${isSelected ? selectedStyles : idleStyles}
+              `}
+            >
+              {isSelected && <span aria-hidden="true">✓ </span>}
+              {label}
+            </button>
+          );
+        })}
+      </div>
+      {submitError && (
+        <p className="text-xs text-red-600 text-center">Failed to submit vote. Please try again.</p>
+      )}
+      {!isAuthenticated && (
+        <p className="text-xs text-gray-500 text-center">Sign in to cast your vote</p>
+      )}
+    </div>
+  );
+}

--- a/tipical-frontend/src/components/tipping/index.ts
+++ b/tipical-frontend/src/components/tipping/index.ts
@@ -1,0 +1,2 @@
+export { TippingPolicyDisplay } from './TippingPolicyDisplay';
+export { TippingPolicySelector } from './TippingPolicySelector';


### PR DESCRIPTION
Closes #6

## Summary

- **`TippingPolicyDisplay`** — reads the vote aggregate for a business and renders the winning policy as a color-coded badge (green = No Tips, yellow = Tips on Subtotal, red = Tips on Total) with a vote count line. Shows a prompt to be the first to vote when no data exists yet.
- **`TippingPolicySelector`** — three-button voting interface. Highlights the user's active vote (`aria-pressed`, checkmark prefix, filled background). Unauthenticated clicks open the auth modal instead of submitting. Buttons are disabled while a mutation is in flight.
- **`index.ts`** — barrel export for both components.

Both components call `useTippingData`; React Query deduplicates the underlying `GET /tipping/votes/{id}` request when both appear on the same page (e.g. inside `BusinessDetailPanel`).

## Test plan

- [ ] Business with votes: badge and count line show correct policy/counts
- [ ] Business with no votes: empty-state message shown
- [ ] Logged-out user clicks a vote button: auth modal opens
- [ ] Logged-in user votes: selected button highlights, count updates after re-fetch
- [ ] Logged-in user changes vote: previous highlight clears, new one appears
- [ ] Buttons disabled while submission is in flight

🤖 Generated with [Claude Code](https://claude.com/claude-code)