### PR TITLE
Implement search functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,9 +155,7 @@ Frontend will be available at `http://localhost:5173`
 - `GET /api/v1/auth/me` - Get current user info (authenticated)
 
 ### Businesses
-- `GET /api/v1/businesses/search` - Search businesses
-- `GET /api/v1/businesses/{id}` - Get business by ID
-- `GET /api/v1/businesses/nearby` - Get nearby businesses
+- `GET /api/v1/businesses/search` - Search businesses (query is optional; omit for proximity-only results)
 
 ### Tipping
 - `GET /api/v1/tipping/votes/{businessId}` - Get vote aggregates

--- a/tipical-frontend/src/App.tsx
+++ b/tipical-frontend/src/App.tsx
@@ -1,35 +1,12 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import { useLocationInit } from './hooks/useLocationInit';
 
 function App() {
-  const [count, setCount] = useState(0)
+  const { isLoading } = useLocationInit();
 
-  return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+  if (isLoading) return null;
+
+  // TODO: render full app layout (issue #8)
+  return <></>;
 }
 
-export default App
+export default App;

--- a/tipical-frontend/src/components/search/SearchBar.tsx
+++ b/tipical-frontend/src/components/search/SearchBar.tsx
@@ -1,0 +1,54 @@
+import { useState, useEffect } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import { useSearchStore } from '../../stores/searchStore';
+import { useGeolocation } from '../../hooks/useGeolocation';
+
+export function SearchBar() {
+  const [inputValue, setInputValue] = useState('');
+
+  const { setQuery, setLocation } = useSearchStore(
+    useShallow(s => ({ setQuery: s.setQuery, setLocation: s.setLocation }))
+  );
+
+  const { requestLocation, isLoading: isLocating, latitude, longitude, error: geoError } = useGeolocation();
+
+  useEffect(() => {
+    const timer = setTimeout(() => setQuery(inputValue), 300);
+    return () => clearTimeout(timer);
+  }, [inputValue, setQuery]);
+
+  useEffect(() => {
+    if (latitude !== null && longitude !== null) {
+      setLocation({ latitude, longitude });
+    }
+  }, [latitude, longitude, setLocation]);
+
+  return (
+    <div className="flex items-center gap-2 bg-white rounded-xl shadow-lg px-4 py-2 w-full max-w-xl">
+      <svg className="w-5 h-5 text-gray-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+      </svg>
+      <input
+        type="text"
+        value={inputValue}
+        onChange={e => setInputValue(e.target.value)}
+        placeholder="Search businesses..."
+        className="flex-1 outline-none text-sm text-gray-900 placeholder-gray-400"
+      />
+      {geoError && (
+        <p className="text-xs text-red-500 flex-shrink-0">Location unavailable</p>
+      )}
+      <button
+        onClick={requestLocation}
+        disabled={isLocating}
+        className="flex-shrink-0 flex items-center gap-1 text-xs text-orange-600 hover:text-orange-700 font-medium disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+      >
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+        </svg>
+        {isLocating ? 'Locating…' : 'Near me'}
+      </button>
+    </div>
+  );
+}

--- a/tipical-frontend/src/components/search/SearchResults.tsx
+++ b/tipical-frontend/src/components/search/SearchResults.tsx
@@ -1,0 +1,98 @@
+import { useShallow } from 'zustand/react/shallow';
+import { Sidebar } from '../common/Sidebar';
+import { useSearchStore } from '../../stores/searchStore';
+import { useUIStore } from '../../stores/uiStore';
+import { useBusinessSearch } from '../../hooks/useBusinessSearch';
+import { TippingPolicy } from '../../types';
+import type { Business, TippingPolicy as TippingPolicyType } from '../../types';
+
+const POLICY_LABELS: Record<TippingPolicyType, string> = {
+  [TippingPolicy.NoTips]: 'No Tips',
+  [TippingPolicy.TipsExcludeTax]: 'Tips on Subtotal',
+  [TippingPolicy.TipsIncludeTax]: 'Tips on Total',
+};
+
+const POLICY_BADGE_STYLES: Record<TippingPolicyType, string> = {
+  [TippingPolicy.NoTips]: 'bg-green-100 text-green-800',
+  [TippingPolicy.TipsExcludeTax]: 'bg-yellow-100 text-yellow-800',
+  [TippingPolicy.TipsIncludeTax]: 'bg-red-100 text-red-800',
+};
+
+const POLICY_RANK: Record<TippingPolicyType, number> = {
+  [TippingPolicy.NoTips]: 0,
+  [TippingPolicy.TipsExcludeTax]: 1,
+  [TippingPolicy.TipsIncludeTax]: 2,
+};
+
+function sortByPolicy(a: Business, b: Business): number {
+  const rankA = a.winningPolicy !== undefined ? POLICY_RANK[a.winningPolicy] : 999;
+  const rankB = b.winningPolicy !== undefined ? POLICY_RANK[b.winningPolicy] : 999;
+  return rankA - rankB;
+}
+
+export function SearchResults() {
+  const { query, location, showResults, setShowResults } = useSearchStore(
+    useShallow(s => ({ query: s.query, location: s.location, showResults: s.showResults, setShowResults: s.setShowResults }))
+  );
+  const openBusinessPanel = useUIStore(s => s.openBusinessPanel);
+
+  const { data: businesses = [], isLoading, error } = useBusinessSearch({
+    query: query.trim() || undefined,
+    latitude: location!.latitude,
+    longitude: location!.longitude,
+  });
+
+  const sorted = [...businesses].sort(sortByPolicy);
+
+  return (
+    <Sidebar
+      isOpen={showResults}
+      onClose={() => setShowResults(false)}
+      title="Results"
+      position="left"
+      width="sm"
+    >
+      {isLoading && (
+        <div className="space-y-3">
+          {[...Array(4)].map((_, i) => (
+            <div key={i} className="animate-pulse h-16 bg-gray-100 rounded-lg" />
+          ))}
+        </div>
+      )}
+
+      {!isLoading && error && (
+        <p className="text-sm text-red-600">Failed to load results. Please try again.</p>
+      )}
+
+      {!isLoading && !error && sorted.length === 0 && (
+        <div className="text-center py-8">
+          <p className="text-sm text-gray-500">No businesses found.</p>
+          <p className="text-xs text-gray-400 mt-1">Try a different search or location.</p>
+        </div>
+      )}
+
+      {!isLoading && !error && sorted.length > 0 && (
+        <ul className="space-y-2">
+          {sorted.map(business => (
+            <li key={business.id}>
+              <button
+                onClick={() => openBusinessPanel(business)}
+                className="w-full text-left p-3 rounded-lg hover:bg-gray-50 transition-colors border border-gray-100"
+              >
+                <p className="text-sm font-medium text-gray-900 truncate">{business.name}</p>
+                <p className="text-xs text-gray-500 truncate mt-0.5">{business.address}</p>
+                {business.winningPolicy !== undefined && (
+                  <span
+                    className={`inline-block mt-1.5 px-2 py-0.5 rounded-full text-xs font-medium ${POLICY_BADGE_STYLES[business.winningPolicy]}`}
+                  >
+                    {POLICY_LABELS[business.winningPolicy]}
+                  </span>
+                )}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Sidebar>
+  );
+}

--- a/tipical-frontend/src/components/search/index.ts
+++ b/tipical-frontend/src/components/search/index.ts
@@ -1,0 +1,2 @@
+export { SearchBar } from './SearchBar';
+export { SearchResults } from './SearchResults';

--- a/tipical-frontend/src/hooks/index.ts
+++ b/tipical-frontend/src/hooks/index.ts
@@ -4,3 +4,4 @@ export { useIpGeolocation } from './useIpGeolocation';
 export { useDebounce } from './useDebounce';
 export { useBusinessSearch, useBusinessById } from './useBusinessSearch';
 export { useTippingData } from './useTippingData';
+export { useLocationInit } from './useLocationInit';

--- a/tipical-frontend/src/hooks/useLocationInit.ts
+++ b/tipical-frontend/src/hooks/useLocationInit.ts
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+import { useIpGeolocation } from './useIpGeolocation';
+import { useSearchStore } from '../stores/searchStore';
+
+/** Initializes the store with IP-based coordinates on app load.
+ *  Runs once; browser geolocation ("Near me") can overwrite later. */
+export function useLocationInit() {
+  const { data, isLoading } = useIpGeolocation();
+  const setLocation = useSearchStore(s => s.setLocation);
+
+  useEffect(() => {
+    if (data) {
+      setLocation({ latitude: data.lat, longitude: data.lng });
+    }
+  }, [data, setLocation]);
+
+  return { isLoading };
+}

--- a/tipical-frontend/src/stores/searchStore.ts
+++ b/tipical-frontend/src/stores/searchStore.ts
@@ -1,0 +1,24 @@
+import { create } from 'zustand';
+
+interface Location {
+  latitude: number;
+  longitude: number;
+}
+
+interface SearchState {
+  query: string;
+  location: Location | null;
+  showResults: boolean;
+  setQuery: (query: string) => void;
+  setLocation: (location: Location) => void;
+  setShowResults: (show: boolean) => void;
+}
+
+export const useSearchStore = create<SearchState>((set) => ({
+  query: '',
+  location: null,
+  showResults: false,
+  setQuery: (query) => set({ query, showResults: Boolean(query.trim()) }),
+  setLocation: (location) => set({ location, showResults: true }),
+  setShowResults: (show) => set({ showResults: show }),
+}));


### PR DESCRIPTION
Closes #4

## Summary
- **`searchStore`** — Zustand store holding the debounced query, user location, and results sidebar visibility. Typing text opens the panel; setting a location always opens it.
- **`useLocationInit`** — initializes the store with IP-based coordinates on app load (via `useIpGeolocation`). App.tsx gates rendering until this resolves, guaranteeing location is always non-null when search components mount.
- **`SearchBar`** — fixed search input with 300ms debounce and a "Near me" button. Uses `useGeolocation` to request browser-native coordinates; if granted, they overwrite the IP-based ones in the store. Surfaces a "Location unavailable" message if permission is denied.
- **`SearchResults`** — left-positioned `Sidebar` listing businesses sorted by tipping policy rank (NoTips → TipsExcludeTax → TipsIncludeTax → unvoted last), with a policy badge per row and click-to-open `BusinessDetailPanel`.

## Notes
- Browser geolocation is optional — IP geolocation provides a city-level fallback with no user interaction required.
- `SearchResults` calls `useBusinessSearch` directly with coordinates from `searchStore`. Query is optional on `GET /businesses/search` (per #28); omitting it produces a proximity-only search.
- `SearchBar` and `SearchResults` are independent components wired through `searchStore`; `App.tsx` (#8) can place them freely without prop-drilling.

## Test plan
- [ ] On load, nearby businesses appear without any user interaction (IP geo fallback)
- [ ] Type in SearchBar — results sidebar opens after 300ms debounce
- [ ] Clear input — results sidebar closes
- [ ] Click "Near me" — browser prompts for location; results update with more precise coordinates
- [ ] Deny location permission — "Location unavailable" message appears
- [ ] Results sorted: businesses with NoTips badge appear before tipped ones
- [ ] Click a result row — BusinessDetailPanel slides in with correct business
- [ ] Close results sidebar — panel hides, reopens correctly on next search

🤖 Generated with [Claude Code](https://claude.com/claude-code)