### PR TITLE
Create frontend Dockerfile and nginx config

### DIFF
--- a/tipical-frontend/.dockerignore
+++ b/tipical-frontend/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/tipical-frontend/Dockerfile
+++ b/tipical-frontend/Dockerfile
@@ -1,0 +1,28 @@
+# Build stage
+FROM node:22-alpine AS build
+WORKDIR /app
+
+# Install dependencies
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Copy source and build
+# VITE_* env vars must be passed as --build-arg and set as ARG/ENV below
+ARG VITE_API_BASE_URL
+ARG VITE_GOOGLE_MAPS_API_KEY
+ARG VITE_GOOGLE_OAUTH_CLIENT_ID
+ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
+ENV VITE_GOOGLE_MAPS_API_KEY=$VITE_GOOGLE_MAPS_API_KEY
+ENV VITE_GOOGLE_OAUTH_CLIENT_ID=$VITE_GOOGLE_OAUTH_CLIENT_ID
+
+COPY . .
+RUN npm run build
+
+# Runtime stage
+FROM nginx:1.27-alpine AS final
+COPY --from=build /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/tipical-frontend/nginx.conf
+++ b/tipical-frontend/nginx.conf
@@ -1,0 +1,23 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Gzip
+    gzip on;
+    gzip_types text/plain text/css application/javascript application/json image/svg+xml;
+    gzip_min_length 1024;
+
+    # Cache static assets (JS/CSS/fonts/images with content hashes)
+    location ~* \.(js|css|woff2?|ttf|eot|svg|png|jpg|jpeg|gif|ico|webp)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # SPA fallback — all other routes serve index.html
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds multi-stage `Dockerfile` for the React frontend: Node 22 Alpine build stage runs `npm run build`, nginx 1.27 Alpine serves the `dist/` output
- Adds `nginx.conf` with SPA fallback (`try_files` → `index.html`), gzip compression, and long-lived cache headers for hashed static assets
- `VITE_*` env vars are accepted as Docker build args and baked in at image build time, matching the CI/CD pipeline expectations

## Test plan
- [ ] `docker build --build-arg VITE_API_BASE_URL=... -t tipical-frontend tipical-frontend/` builds successfully
- [ ] Container serves the app at port 80
- [ ] Navigating directly to a deep route (e.g. `/businesses/123`) returns `index.html` (SPA routing works)
- [ ] Static assets respond with `Cache-Control: public, immutable`

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)