### PR TITLE
Restrict test environment to allowlisted users

### DIFF
--- a/tipical-backend/src/Tipical.Api/AllowedUsersOptions.cs
+++ b/tipical-backend/src/Tipical.Api/AllowedUsersOptions.cs
@@ -1,0 +1,7 @@
+namespace Tipical.Api;
+
+public class AllowedUsersOptions
+{
+    public bool Enabled { get; set; } = false;
+    public string Emails { get; set; } = string.Empty;
+}

--- a/tipical-backend/src/Tipical.Api/Controllers/AuthController.cs
+++ b/tipical-backend/src/Tipical.Api/Controllers/AuthController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 using Tipical.Core.DTOs;
 using Tipical.Core.Services;
 
@@ -7,16 +8,29 @@ namespace Tipical.Api.Controllers;
 
 [ApiController]
 [Route("api/v1/auth")]
-public class AuthController(IGoogleAuthService googleAuthService, ILogger<AuthController> logger) : ControllerBase
+public class AuthController(
+    IGoogleAuthService googleAuthService,
+    IOptions<AllowedUsersOptions> allowedUsers,
+    ILogger<AuthController> logger) : ControllerBase
 {
     [HttpPost("google")]
     [ProducesResponseType(typeof(AuthResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<ActionResult<AuthResponse>> GoogleAuth([FromBody] GoogleAuthRequest request)
     {
         try
         {
             var response = await googleAuthService.VerifyGoogleTokenAsync(request.IdToken);
+
+            var options = allowedUsers.Value;
+            var emailList = options.Emails.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (options.Enabled && !emailList.Contains(response.Email, StringComparer.OrdinalIgnoreCase))
+            {
+                logger.LogWarning("Blocked sign-in attempt from non-allowlisted email: {Email}", response.Email);
+                return StatusCode(StatusCodes.Status403Forbidden, new { message = "Access restricted" });
+            }
+
             return Ok(response);
         }
         catch (UnauthorizedAccessException ex)

--- a/tipical-backend/src/Tipical.Api/Program.cs
+++ b/tipical-backend/src/Tipical.Api/Program.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Tipical.Api;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using System.Text;
@@ -45,6 +46,8 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     });
 
 builder.Services.AddAuthorization();
+
+builder.Services.Configure<AllowedUsersOptions>(builder.Configuration.GetSection("AllowedUsers"));
 
 // Configure CORS
 var allowedOrigins = builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>()!;

--- a/tipical-backend/src/Tipical.Api/appsettings.json
+++ b/tipical-backend/src/Tipical.Api/appsettings.json
@@ -23,5 +23,9 @@
   },
   "Cors": {
     "AllowedOrigins": ["http://localhost:5173", "http://localhost:3000"]
+  },
+  "AllowedUsers": {
+    "Enabled": false,
+    "Emails": ""
   }
 }


### PR DESCRIPTION
## Summary
- Adds `AllowedUsersOptions` config class (`Enabled`, `Emails` as a comma-separated string)
- Wires it up in `Program.cs` via `Configure<AllowedUsersOptions>`
- In `POST /api/v1/auth/google`, after a valid Google token is verified, returns `403` if `AllowedUsers.Enabled` is true and the email is not in the comma-separated list
- Adds `AllowedUsers: { Enabled: false, Emails: "" }` to `appsettings.json` (disabled by default)

To enable on the test Cloud Run service, set env vars:
```
AllowedUsers__Enabled=true
AllowedUsers__Emails=you@example.com,other@example.com
```

Prod leaves `Enabled: false` — no restriction applied.

## Test plan
- [ ] Build passes (`dotnet build`)
- [ ] Sign in with an allowlisted email when `Enabled: true` → succeeds
- [ ] Sign in with a non-allowlisted email when `Enabled: true` → returns `403`
- [ ] Sign in with multiple emails in the list → all succeed
- [ ] Emails with extra whitespace around commas are handled correctly
- [ ] Sign in with any email when `Enabled: false` → succeeds

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)