### PR TITLE
Fix null id on tipping_votes insert

### DIFF
--- a/tipical-backend/src/Tipical.Infrastructure/Data/Configurations/TippingVoteConfiguration.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Data/Configurations/TippingVoteConfiguration.cs
@@ -14,7 +14,7 @@ public class TippingVoteConfiguration : IEntityTypeConfiguration<TippingVote>
 
         builder.Property(tv => tv.Id)
             .HasColumnName("id")
-            .ValueGeneratedOnAdd();
+            .ValueGeneratedNever();
 
         builder.Property(tv => tv.BusinessId)
             .HasColumnName("business_id")


### PR DESCRIPTION
fixes #58 — `ValueGeneratedOnAdd` told EF Core/FlexLabs Upsert to omit `id` from the INSERT, but the column has no server-side default. Switching to `ValueGeneratedNever` so the client-supplied `Guid.NewGuid()` is included. No migration needed.