### PR TITLE
Fix map pin color not updating after casting a vote

### DIFF
--- a/tipical-frontend/src/hooks/useTippingData.ts
+++ b/tipical-frontend/src/hooks/useTippingData.ts
@@ -1,7 +1,8 @@
+import { useEffect } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { tippingService } from '../services/tippingService';
 import { useAuthStore } from '../stores/authStore';
-import type { TippingVote, TippingVotesAggregate, TippingPolicy } from '../types';
+import type { Business, TippingVote, TippingVotesAggregate, TippingPolicy } from '../types';
 
 export function useTippingData(googlePlaceId: string | null) {
   const queryClient = useQueryClient();
@@ -18,6 +19,22 @@ export function useTippingData(googlePlaceId: string | null) {
     queryFn: () => tippingService.getUserVote(googlePlaceId!),
     enabled: Boolean(googlePlaceId) && isAuthenticated,
   });
+
+  // Mirror the latest aggregate into every business search cache entry so map
+  // pins reflect the current winning policy without a separate search refetch.
+  useEffect(() => {
+    if (!votesQuery.data || !googlePlaceId) return;
+    const { winningPolicy, winningPolicyVoteCount } = votesQuery.data;
+    queryClient.setQueriesData<Business[]>(
+      { queryKey: ['businesses', 'search'], exact: false },
+      (businesses) =>
+        businesses?.map(b =>
+          b.googlePlaceId === googlePlaceId
+            ? { ...b, winningPolicy, winningPolicyVoteCount: winningPolicyVoteCount ?? undefined }
+            : b
+        )
+    );
+  }, [votesQuery.data, googlePlaceId, queryClient]);
 
   const submitVoteMutation = useMutation<TippingVote, Error, TippingPolicy>({
     mutationFn: (policy) =>


### PR DESCRIPTION
Closes #63.

## Summary

- `winningPolicy` on `Business` objects in the search cache was never updated when votes changed, so map pins kept their pre-vote color until the next search refetch
- Adds a `useEffect` in `useTippingData` that writes `winningPolicy` and `winningPolicyVoteCount` into every matching business across all search cache slices whenever the votes aggregate settles
- No extra API call — the aggregate is already fetched as part of the normal tipping data flow; the effect just mirrors it into the business cache

## Test plan

- [ ] Open the map, note a business pin color (or gray for unvoted)
- [ ] Click the business, cast a vote in the detail panel
- [ ] Without refreshing, confirm the map pin recolors to match the winning policy
- [ ] Cast a tie-breaking vote (requires two users or manual DB seeding) — confirm pin flips to the new winner
- [ ] Confirm the winning policy badge in the detail panel still updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)