### PR TITLE
Replace "Near me" with "Search this area" button driven by map pan/zoom

### DIFF
--- a/tipical-frontend/src/App.tsx
+++ b/tipical-frontend/src/App.tsx
@@ -11,19 +11,13 @@ import { UserProfile, GoogleAuthModal } from './components/auth';
 import { Loading } from './components/common';
 
 function AppLayout() {
-  const { location, query } = useSearchStore(
-    useShallow(s => ({ location: s.location, query: s.query }))
+  const { searchCenter, query } = useSearchStore(
+    useShallow(s => ({ searchCenter: s.searchCenter, query: s.query }))
   );
-  const setCenter = useMapStore(s => s.setCenter);
-
-  useEffect(() => {
-    setCenter({ lat: location!.latitude, lng: location!.longitude });
-  }, [location, setCenter]);
 
   const { data: businesses = [] } = useBusinessSearch({
     query: query.trim() || undefined,
-    latitude: location!.latitude,
-    longitude: location!.longitude,
+    searchCenter: searchCenter!,
   });
 
   return (
@@ -46,14 +40,19 @@ function AppLayout() {
 
 function App() {
   const initialLocation = useInitialLocation();
-  const setLocation = useSearchStore(s => s.setLocation);
-  const location = useSearchStore(s => s.location);
+  const setSearchCenter = useSearchStore(s => s.setSearchCenter);
+  const searchCenter = useSearchStore(s => s.searchCenter);
+  const setCenter = useMapStore(s => s.setCenter);
 
   useEffect(() => {
-    if (initialLocation) setLocation(initialLocation);
-  }, [initialLocation, setLocation]);
+    if (initialLocation) {
+      const zoom = useMapStore.getState().zoom;
+      setSearchCenter({ ...initialLocation, zoom });
+      setCenter({ lat: initialLocation.latitude, lng: initialLocation.longitude });
+    }
+  }, [initialLocation, setSearchCenter, setCenter]);
 
-  if (!location) return <Loading fullScreen />;
+  if (!searchCenter) return <Loading fullScreen />;
 
   return <AppLayout />;
 }

--- a/tipical-frontend/src/components/map/GoogleMap.tsx
+++ b/tipical-frontend/src/components/map/GoogleMap.tsx
@@ -5,6 +5,7 @@ import { useUIStore } from '../../stores/uiStore';
 import { useGeolocation } from '../../hooks';
 import type { Business } from '../../types';
 import { BusinessMarker } from './BusinessMarker';
+import { SearchThisAreaButton } from './SearchThisAreaButton';
 
 // Stable reference — must not be recreated on each render
 const LIBRARIES: ['places'] = ['places'];
@@ -122,6 +123,7 @@ export function GoogleMap({ businesses = [] }: GoogleMapProps) {
 
   return (
     <div className="relative w-full h-full">
+      <SearchThisAreaButton />
       <GoogleMapBase
         mapContainerStyle={MAP_CONTAINER_STYLE}
         center={center}

--- a/tipical-frontend/src/components/map/SearchThisAreaButton.tsx
+++ b/tipical-frontend/src/components/map/SearchThisAreaButton.tsx
@@ -1,0 +1,28 @@
+import { useMapStore } from '../../stores/mapStore';
+import { useSearchStore } from '../../stores/searchStore';
+import { useUIStore } from '../../stores/uiStore';
+import { useSearchAreaChanged } from '../../hooks/useSearchAreaChanged';
+
+export function SearchThisAreaButton() {
+  const center = useMapStore(s => s.center);
+  const zoom = useMapStore(s => s.zoom);
+  const setSearchCenter = useSearchStore(s => s.setSearchCenter);
+  const setShowSearchThisArea = useUIStore(s => s.setShowSearchThisArea);
+  const visible = useSearchAreaChanged();
+
+  if (!visible || !center) return null;
+
+  return (
+    <div className="absolute top-3 inset-x-0 flex justify-center pointer-events-none z-10">
+      <button
+        onClick={() => {
+          setSearchCenter({ latitude: center.lat, longitude: center.lng, zoom });
+          setShowSearchThisArea(false);
+        }}
+        className="pointer-events-auto bg-white text-gray-800 text-sm font-medium px-4 py-2 rounded-full shadow-md hover:bg-gray-50 transition-colors border border-gray-200"
+      >
+        Search this area
+      </button>
+    </div>
+  );
+}

--- a/tipical-frontend/src/components/map/index.ts
+++ b/tipical-frontend/src/components/map/index.ts
@@ -1,3 +1,4 @@
 export { GoogleMap } from './GoogleMap';
 export { BusinessMarker } from './BusinessMarker';
 export { BusinessInfoWindow } from './BusinessInfoWindow';
+export { SearchThisAreaButton } from './SearchThisAreaButton';

--- a/tipical-frontend/src/components/search/SearchBar.tsx
+++ b/tipical-frontend/src/components/search/SearchBar.tsx
@@ -1,22 +1,9 @@
-import { useState, useEffect } from 'react';
-import { useShallow } from 'zustand/react/shallow';
+import { useState } from 'react';
 import { useSearchStore } from '../../stores/searchStore';
-import { useGeolocation } from '../../hooks/useGeolocation';
 
 export function SearchBar() {
   const [inputValue, setInputValue] = useState('');
-
-  const { setQuery, setLocation } = useSearchStore(
-    useShallow(s => ({ setQuery: s.setQuery, setLocation: s.setLocation }))
-  );
-
-  const { requestLocation, isLoading: isLocating, latitude, longitude, error: geoError } = useGeolocation();
-
-  useEffect(() => {
-    if (latitude !== null && longitude !== null) {
-      setLocation({ latitude, longitude });
-    }
-  }, [latitude, longitude, setLocation]);
+  const setQuery = useSearchStore(s => s.setQuery);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -40,21 +27,6 @@ export function SearchBar() {
         placeholder="Search businesses..."
         className="flex-1 outline-none text-sm text-gray-900 placeholder-gray-400"
       />
-      {geoError && (
-        <p className="text-xs text-red-500 flex-shrink-0">Location unavailable</p>
-      )}
-      <button
-        type="button"
-        onClick={requestLocation}
-        disabled={isLocating}
-        className="flex-shrink-0 flex items-center gap-1 text-xs text-orange-600 hover:text-orange-700 font-medium disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-      >
-        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
-        </svg>
-        {isLocating ? 'Locating…' : 'Near me'}
-      </button>
     </form>
   );
 }

--- a/tipical-frontend/src/components/search/SearchResults.tsx
+++ b/tipical-frontend/src/components/search/SearchResults.tsx
@@ -31,15 +31,14 @@ function sortByPolicy(a: Business, b: Business): number {
 }
 
 export function SearchResults() {
-  const { query, location, showResults, setShowResults } = useSearchStore(
-    useShallow(s => ({ query: s.query, location: s.location, showResults: s.showResults, setShowResults: s.setShowResults }))
+  const { query, searchCenter, showResults, setShowResults } = useSearchStore(
+    useShallow(s => ({ query: s.query, searchCenter: s.searchCenter, showResults: s.showResults, setShowResults: s.setShowResults }))
   );
   const openBusinessPanel = useUIStore(s => s.openBusinessPanel);
 
   const { data: businesses = [], isLoading, error } = useBusinessSearch({
     query: query.trim() || undefined,
-    latitude: location!.latitude,
-    longitude: location!.longitude,
+    searchCenter: searchCenter!,
   });
 
   const sorted = [...businesses].sort(sortByPolicy);

--- a/tipical-frontend/src/hooks/index.ts
+++ b/tipical-frontend/src/hooks/index.ts
@@ -4,3 +4,4 @@ export { useInitialLocation } from './useInitialLocation';
 export { useDebounce } from './useDebounce';
 export { useBusinessSearch, useBusinessById } from './useBusinessSearch';
 export { useTippingData } from './useTippingData';
+export { useSearchAreaChanged } from './useSearchAreaChanged';

--- a/tipical-frontend/src/hooks/useBusinessSearch.ts
+++ b/tipical-frontend/src/hooks/useBusinessSearch.ts
@@ -1,27 +1,22 @@
 import { useQuery } from '@tanstack/react-query';
 import { businessService } from '../services/businessService';
+import { radiusFromZoom } from '../utils/geo';
+import type { SearchCenter } from '../stores/searchStore';
 import type { Business } from '../types';
 
 interface UseBusinessSearchOptions {
   query?: string;
-  latitude: number;
-  longitude: number;
-  radius?: number;
+  searchCenter: SearchCenter;
 }
 
-export function useBusinessSearch({
-  query,
-  latitude,
-  longitude,
-  radius = 5000,
-}: UseBusinessSearchOptions) {
-  const roundedLat = Math.round(latitude * 1e4) / 1e4;
-  const roundedLng = Math.round(longitude * 1e4) / 1e4;
+export function useBusinessSearch({ query, searchCenter }: UseBusinessSearchOptions) {
+  const radius = radiusFromZoom(searchCenter.zoom);
+  const roundedLat = Math.round(searchCenter.latitude * 1e4) / 1e4;
+  const roundedLng = Math.round(searchCenter.longitude * 1e4) / 1e4;
 
   return useQuery<Business[]>({
     queryKey: ['businesses', 'search', { query, latitude: roundedLat, longitude: roundedLng, radius }],
-    queryFn: () => businessService.search(query?.trim() || undefined, latitude, longitude, radius),
-    enabled: true,
+    queryFn: () => businessService.search(query?.trim() || undefined, searchCenter.latitude, searchCenter.longitude, radius),
   });
 }
 

--- a/tipical-frontend/src/hooks/useSearchAreaChanged.ts
+++ b/tipical-frontend/src/hooks/useSearchAreaChanged.ts
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+import { useMapStore } from '../stores/mapStore';
+import { useSearchStore } from '../stores/searchStore';
+import { useUIStore } from '../stores/uiStore';
+import { haversineDistance, radiusFromZoom } from '../utils/geo';
+
+export function useSearchAreaChanged(): boolean {
+  const center = useMapStore(s => s.center);
+  const zoom = useMapStore(s => s.zoom);
+  const searchCenter = useSearchStore(s => s.searchCenter);
+  const showSearchThisArea = useUIStore(s => s.showSearchThisArea);
+  const setShowSearchThisArea = useUIStore(s => s.setShowSearchThisArea);
+
+  useEffect(() => {
+    if (!center || !searchCenter) return;
+
+    const zoomChanged = zoom !== searchCenter.zoom;
+    const radius = radiusFromZoom(zoom);
+    const distance = haversineDistance(center.lat, center.lng, searchCenter.latitude, searchCenter.longitude);
+    const pannedFarEnough = distance > radius * 0.3;
+
+    if (zoomChanged || pannedFarEnough) {
+      setShowSearchThisArea(true);
+    }
+  }, [center, zoom, searchCenter, setShowSearchThisArea]);
+
+  return showSearchThisArea;
+}

--- a/tipical-frontend/src/stores/searchStore.ts
+++ b/tipical-frontend/src/stores/searchStore.ts
@@ -1,24 +1,25 @@
 import { create } from 'zustand';
 
-interface Location {
+export interface SearchCenter {
   latitude: number;
   longitude: number;
+  zoom: number;
 }
 
 interface SearchState {
   query: string;
-  location: Location | null;
+  searchCenter: SearchCenter | null;
   showResults: boolean;
   setQuery: (query: string) => void;
-  setLocation: (location: Location) => void;
+  setSearchCenter: (center: SearchCenter) => void;
   setShowResults: (show: boolean) => void;
 }
 
 export const useSearchStore = create<SearchState>((set) => ({
   query: '',
-  location: null,
+  searchCenter: null,
   showResults: false,
   setQuery: (query) => set({ query, showResults: Boolean(query.trim()) }),
-  setLocation: (location) => set({ location }),
+  setSearchCenter: (searchCenter) => set({ searchCenter }),
   setShowResults: (show) => set({ showResults: show }),
 }));

--- a/tipical-frontend/src/stores/uiStore.ts
+++ b/tipical-frontend/src/stores/uiStore.ts
@@ -5,18 +5,22 @@ interface UIState {
   showAuthModal: boolean;
   selectedBusiness: Business | null;
   showBusinessPanel: boolean;
+  showSearchThisArea: boolean;
   setShowAuthModal: (show: boolean) => void;
   setShowBusinessPanel: (show: boolean) => void;
   openBusinessPanel: (business: Business) => void;
   closeBusinessPanel: () => void;
+  setShowSearchThisArea: (show: boolean) => void;
 }
 
 export const useUIStore = create<UIState>((set) => ({
   showAuthModal: false,
   selectedBusiness: null,
   showBusinessPanel: false,
+  showSearchThisArea: false,
   setShowAuthModal: (show) => set({ showAuthModal: show }),
   setShowBusinessPanel: (show) => set({ showBusinessPanel: show }),
   openBusinessPanel: (business) => set({ selectedBusiness: business, showBusinessPanel: true }),
   closeBusinessPanel: () => set({ selectedBusiness: null, showBusinessPanel: false }),
+  setShowSearchThisArea: (show) => set({ showSearchThisArea: show }),
 }));

--- a/tipical-frontend/src/utils/geo.ts
+++ b/tipical-frontend/src/utils/geo.ts
@@ -1,0 +1,14 @@
+export function haversineDistance(lat1: number, lon1: number, lat2: number, lon2: number): number {
+  const R = 6_371_000;
+  const φ1 = (lat1 * Math.PI) / 180;
+  const φ2 = (lat2 * Math.PI) / 180;
+  const Δφ = ((lat2 - lat1) * Math.PI) / 180;
+  const Δλ = ((lon2 - lon1) * Math.PI) / 180;
+  const a = Math.sin(Δφ / 2) ** 2 + Math.cos(φ1) * Math.cos(φ2) * Math.sin(Δλ / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+// Zoom 13 → 5 000 m; each step halves/doubles. Capped at Google Places' 50 000 m max.
+export function radiusFromZoom(zoom: number): number {
+  return Math.min(50_000, Math.round(5_000 * Math.pow(2, 13 - zoom)));
+}


### PR DESCRIPTION
Closes #65

## Summary
- Removes the "Near me" GPS button from the search bar; the search bar is now text-only
- Adds a "Search this area" floating button that appears over the map only when the user has panned or zoomed far enough from the last search origin (>30% of the current search radius, or any zoom change)
- Derives the search radius from the zoom level (`zoom 13 → 5 km`, halving/doubling per step) instead of a hardcoded 5 000 m
- The crosshair button remains unchanged; after clicking it, "Search this area" will appear since the map moved

## Architecture
- **`src/utils/geo.ts`** (new) — `haversineDistance` and `radiusFromZoom` shared utilities
- **`src/stores/searchStore.ts`** — replaces `location: {lat,lng}` with `searchCenter: {lat,lng,zoom}`
- **`src/hooks/useSearchAreaChanged.ts`** (new) — compares `mapStore` viewport against `searchStore.searchCenter`; returns `true` when the button should be visible
- **`src/hooks/useBusinessSearch.ts`** — accepts `searchCenter` instead of separate lat/lng/radius; derives radius from zoom
- **`src/components/map/SearchThisAreaButton.tsx`** (new) — reads `useSearchAreaChanged()`, renders null when hidden, updates `searchCenter` on click
- **`src/App.tsx`** — initialises both `searchCenter` and `mapStore.center` from `useInitialLocation`; removes the old effect that synced `location → mapStore.center`
- **`src/components/search/SearchBar.tsx`** — removed `useGeolocation`, GPS effect, and "Near me" button

## Test plan
- [ ] On load, map centres on initial location and businesses load
- [ ] "Search this area" button is hidden on load
- [ ] Panning the map a meaningful distance shows the button
- [ ] Zooming in or out shows the button
- [ ] Clicking "Search this area" dismisses the button and reloads businesses for the new viewport
- [ ] Crosshair button still navigates to GPS location; "Search this area" then appears
- [ ] Text search still works and shows the results sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)