### PR TITLE
Fix infinite re-render loop on map pan/zoom

### DIFF
--- a/tipical-frontend/src/components/map/GoogleMap.tsx
+++ b/tipical-frontend/src/components/map/GoogleMap.tsx
@@ -32,11 +32,9 @@ export function GoogleMap({ businesses = [] }: GoogleMapProps) {
   const center = useMapStore(s => s.center);
   const zoom = useMapStore(s => s.zoom);
   const setCenter = useMapStore(s => s.setCenter);
-  const setZoom = useMapStore(s => s.setZoom);
   const closeBusinessPanel = useUIStore(s => s.closeBusinessPanel);
 
   const [activeMarkerId, setActiveMarkerId] = useState<string | null>(null);
-  const [map, setMap] = useState<google.maps.Map | null>(null);
 
   // Memoized after isLoaded so google.maps.Size is available; deps array is intentionally [isLoaded].
   const userLocationIcon = useMemo(
@@ -79,18 +77,6 @@ export function GoogleMap({ businesses = [] }: GoogleMapProps) {
     []
   );
 
-  const handleLoad = useCallback((m: google.maps.Map) => setMap(m), []);
-
-  const handleCenterChanged = useCallback(() => {
-    const c = map?.getCenter();
-    if (c) setCenter({ lat: c.lat(), lng: c.lng() });
-  }, [map, setCenter]);
-
-  const handleZoomChanged = useCallback(() => {
-    const z = map?.getZoom();
-    if (z !== undefined) setZoom(z);
-  }, [map, setZoom]);
-
   const handleMapClick = useCallback(() => {
     setActiveMarkerId(null);
     closeBusinessPanel();
@@ -127,9 +113,6 @@ export function GoogleMap({ businesses = [] }: GoogleMapProps) {
         center={center}
         zoom={zoom}
         options={mapOptions}
-        onLoad={handleLoad}
-        onCenterChanged={handleCenterChanged}
-        onZoomChanged={handleZoomChanged}
         onClick={handleMapClick}
       >
         {/* GPS user location blue dot — only shown after permission is granted */}


### PR DESCRIPTION
closes #67

## Summary
- Removed `onCenterChanged` and `onZoomChanged` event handlers from `GoogleMapBase` — these were reading map position and writing it back to the Zustand store, which re-rendered the component with new controlled props, which triggered the events again, causing an infinite loop.
- Removed the now-unused `handleCenterChanged` and `handleZoomChanged` callbacks, the `map`/`setMap` state, and the `handleLoad` callback that only existed to capture the map instance for those handlers.
- The store's `center` and `zoom` values continue to drive initial positioning and programmatic re-centering (GPS / "My Location") — only the feedback path from map → store was removed.

## Test plan
- [ ] Pan the map — no crash, map moves freely
- [ ] Zoom the map — no crash, zoom changes freely
- [ ] Click "My Location" — map re-centers on GPS coordinates without crashing
- [ ] Verify business markers remain visible and clickable after panning/zooming