### PR TITLE
Remove TanStack Query DevTools

### DIFF
--- a/tipical-frontend/package-lock.json
+++ b/tipical-frontend/package-lock.json
@@ -22,7 +22,6 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
-        "@tanstack/react-query-devtools": "^5.91.2",
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.5",
         "@types/react-dom": "^19.2.3",
@@ -1644,17 +1643,6 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
-    "node_modules/@tanstack/query-devtools": {
-      "version": "5.92.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.92.0.tgz",
-      "integrity": "sha512-N8D27KH1vEpVacvZgJL27xC6yPFUy0Zkezn5gnB3L3gRCxlDeSuiya7fKge8Y91uMTnC8aSxBQhcK6ocY7alpQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
     "node_modules/@tanstack/react-query": {
       "version": "5.90.19",
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.19.tgz",
@@ -1669,24 +1657,6 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "react": "^18 || ^19"
-      }
-    },
-    "node_modules/@tanstack/react-query-devtools": {
-      "version": "5.91.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.91.2.tgz",
-      "integrity": "sha512-ZJ1503ay5fFeEYFUdo7LMNFzZryi6B0Cacrgr2h1JRkvikK1khgIq6Nq2EcblqEdIlgB/r7XDW8f8DQ89RuUgg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/query-devtools": "5.92.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "@tanstack/react-query": "^5.90.14",
         "react": "^18 || ^19"
       }
     },

--- a/tipical-frontend/package.json
+++ b/tipical-frontend/package.json
@@ -24,7 +24,6 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
-    "@tanstack/react-query-devtools": "^5.91.2",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",

--- a/tipical-frontend/src/main.tsx
+++ b/tipical-frontend/src/main.tsx
@@ -1,7 +1,6 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { QueryClientProvider } from '@tanstack/react-query'
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { GoogleOAuthProvider } from '@react-oauth/google'
 import './index.css'
 import App from './App.tsx'
@@ -19,7 +18,6 @@ createRoot(document.getElementById('root')!).render(
     <GoogleOAuthProvider clientId={googleClientId}>
       <QueryClientProvider client={queryClient}>
         <App />
-        <ReactQueryDevtools initialIsOpen={false} />
       </QueryClientProvider>
     </GoogleOAuthProvider>
   </StrictMode>,


### PR DESCRIPTION
Closes #69

## Summary
- Removes `ReactQueryDevtools` import and component from `main.tsx`
- Uninstalls `@tanstack/react-query-devtools` package

## Test plan
- [ ] App loads without the query devtools panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)