### PR TITLE
Keep old map pins visible during "Search this area" fetch, show loading state on button

### DIFF
--- a/tipical-frontend/src/App.tsx
+++ b/tipical-frontend/src/App.tsx
@@ -25,14 +25,14 @@ function AppLayout({ initialCenter, initialZoom }: AppLayoutProps) {
     useShallow(s => ({ searchCenter: s.searchCenter, query: s.query }))
   );
 
-  const { data: businesses = [] } = useBusinessSearch({
+  const { data: businesses = [], isPlaceholderData } = useBusinessSearch({
     query: query.trim() || undefined,
     searchCenter,
   });
 
   return (
     <div className="relative w-screen h-screen overflow-hidden">
-      <GoogleMap businesses={businesses} initialCenter={initialCenter} initialZoom={initialZoom} />
+      <GoogleMap businesses={businesses} isSearching={isPlaceholderData} initialCenter={initialCenter} initialZoom={initialZoom} />
 
       <div className="absolute top-4 inset-x-0 z-10 flex items-center justify-center px-4">
         <SearchBar />

--- a/tipical-frontend/src/components/map/GoogleMap.tsx
+++ b/tipical-frontend/src/components/map/GoogleMap.tsx
@@ -19,11 +19,12 @@ const USER_LOCATION_ICON_URL = `data:image/svg+xml;charset=UTF-8,${USER_LOCATION
 
 interface GoogleMapProps {
   businesses?: Business[];
+  isSearching?: boolean;
   initialCenter: { lat: number; lng: number };
   initialZoom: number;
 }
 
-export function GoogleMap({ businesses = [], initialCenter, initialZoom }: GoogleMapProps) {
+export function GoogleMap({ businesses = [], isSearching = false, initialCenter, initialZoom }: GoogleMapProps) {
   const closeBusinessPanel = useUIStore(s => s.closeBusinessPanel);
 
   const [center, setCenter] = useState(initialCenter);
@@ -106,7 +107,7 @@ export function GoogleMap({ businesses = [], initialCenter, initialZoom }: Googl
 
   return (
     <div className="relative w-full h-full">
-      <SearchThisAreaButton center={center} zoom={zoom} />
+      <SearchThisAreaButton center={center} zoom={zoom} isSearching={isSearching} />
       <GoogleMapBase
         mapContainerStyle={MAP_CONTAINER_STYLE}
         center={initialCenter}

--- a/tipical-frontend/src/components/map/SearchThisAreaButton.tsx
+++ b/tipical-frontend/src/components/map/SearchThisAreaButton.tsx
@@ -4,20 +4,25 @@ import { useSearchAreaChanged } from '../../hooks/useSearchAreaChanged';
 interface SearchThisAreaButtonProps {
   center: { lat: number; lng: number };
   zoom: number;
+  isSearching?: boolean;
 }
 
-export function SearchThisAreaButton({ center, zoom }: SearchThisAreaButtonProps) {
+export function SearchThisAreaButton({ center, zoom, isSearching = false }: SearchThisAreaButtonProps) {
   const setSearchCenter = useSearchStore(s => s.setSearchCenter);
   const visible = useSearchAreaChanged(center, zoom);
 
-  if (!visible) return null;
+  if (!visible && !isSearching) return null;
 
   return (
     <div className="absolute top-3 inset-x-0 flex justify-center pointer-events-none z-10">
       <button
         onClick={() => setSearchCenter({ latitude: center.lat, longitude: center.lng, zoom })}
-        className="pointer-events-auto bg-white text-gray-800 text-sm font-medium px-4 py-2 rounded-full shadow-md hover:bg-gray-50 transition-colors border border-gray-200"
+        disabled={isSearching}
+        className="pointer-events-auto inline-flex items-center gap-2 bg-white text-gray-800 text-sm font-medium px-4 py-2 rounded-full shadow-md hover:bg-gray-50 disabled:hover:bg-white disabled:cursor-not-allowed disabled:opacity-80 transition-colors border border-gray-200"
       >
+        {isSearching && (
+          <div className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-gray-400 border-t-transparent" aria-hidden="true" />
+        )}
         Search this area
       </button>
     </div>

--- a/tipical-frontend/src/hooks/useBusinessSearch.ts
+++ b/tipical-frontend/src/hooks/useBusinessSearch.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, keepPreviousData } from '@tanstack/react-query';
 import { businessService } from '../services/businessService';
 import { radiusFromZoom } from '../utils/geo';
 import type { SearchCenter } from '../stores/searchStore';
@@ -17,6 +17,7 @@ export function useBusinessSearch({ query, searchCenter }: UseBusinessSearchOpti
   return useQuery<Business[]>({
     queryKey: ['businesses', 'search', { query, latitude: roundedLat, longitude: roundedLng, radius }],
     queryFn: () => businessService.search(query?.trim() || undefined, searchCenter.latitude, searchCenter.longitude, radius),
+    placeholderData: keepPreviousData,
   });
 }
 


### PR DESCRIPTION
Closes #83

## Summary

- `useBusinessSearch` now uses `keepPreviousData` so the previous pin set stays on the map while the new fetch is in flight — pins swap out atomically when results arrive instead of flashing empty
- `isPlaceholderData` is threaded from `AppLayout` → `GoogleMap` → `SearchThisAreaButton` as `isSearching`
- While `isSearching`, the button shows a small inline spinner and is disabled to prevent duplicate searches
- The button also stays mounted during a fetch even if `useSearchAreaChanged` returns false, so the spinner remains visible throughout

## Test plan

- [ ] Pan the map and click **Search this area** — old pins should remain visible until new ones load
- [ ] Confirm the button shows a spinner and is non-clickable during the fetch
- [ ] Confirm the button disappears (or transitions to normal) once results land
- [ ] Confirm normal button appearance and behavior when not searching

🤖 Generated with [Claude Code](https://claude.com/claude-code)