### PR TITLE
Add Firebase Hosting configuration (closes #40)

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,17 @@
+{
+  "projects": {
+    "default": "tipical"
+  },
+  "targets": {
+    "tipical": {
+      "hosting": {
+        "tipical-test": [
+          "tipical-test"
+        ],
+        "tipical": [
+          "tipical"
+        ]
+      }
+    }
+  }
+}

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,74 @@
+{
+  "hosting": [
+    {
+      "target": "tipical-test",
+      "public": "tipical-frontend/dist",
+      "ignore": [
+        "firebase.json",
+        "**/.*",
+        "**/node_modules/**"
+      ],
+      "rewrites": [
+        {
+          "source": "**",
+          "destination": "/index.html"
+        }
+      ],
+      "headers": [
+        {
+          "source": "/index.html",
+          "headers": [
+            {
+              "key": "Cache-Control",
+              "value": "no-cache"
+            }
+          ]
+        },
+        {
+          "source": "/assets/**",
+          "headers": [
+            {
+              "key": "Cache-Control",
+              "value": "max-age=31536000,immutable"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "target": "tipical",
+      "public": "tipical-frontend/dist",
+      "ignore": [
+        "firebase.json",
+        "**/.*",
+        "**/node_modules/**"
+      ],
+      "rewrites": [
+        {
+          "source": "**",
+          "destination": "/index.html"
+        }
+      ],
+      "headers": [
+        {
+          "source": "/index.html",
+          "headers": [
+            {
+              "key": "Cache-Control",
+              "value": "no-cache"
+            }
+          ]
+        },
+        {
+          "source": "/assets/**",
+          "headers": [
+            {
+              "key": "Cache-Control",
+              "value": "max-age=31536000,immutable"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `firebase.json` with two named hosting targets (`tipical-test` and `tipical`) both pointing at `tipical-frontend/dist`
- Configures SPA rewrite (all paths → `/index.html`) and cache headers (`index.html: no-cache`, `assets/**: max-age=31536000,immutable`)
- Adds `.firebaserc` mapping both targets to their Firebase Hosting site IDs under the `tipical` GCP/Firebase project

## Test plan
- [ ] Verify `firebase deploy --only hosting:tipical-test` resolves correctly once #38 workflow runs
- [ ] Verify `firebase deploy --only hosting:tipical` resolves correctly once #39 workflow runs
- [ ] Confirm SPA routing works (deep links don't 404 on hard reload)
- [ ] Confirm `assets/` files are served with immutable cache headers and `index.html` with `no-cache`

## Notes
The `tipical-test` and `tipical` site IDs match the Firebase Hosting sites created in #36. This config unblocks the `build-and-deploy-frontend-test` job in #38 and the equivalent prod job in #39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)