### PR TITLE
Add id-token write permission for WIF auth

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+  id-token: write
+
 env:
   REGION: us-central1
 


### PR DESCRIPTION
Closes #90

## Summary

Adds a `permissions` block to `deploy-test.yml`:

```yaml
permissions:
  contents: read
  id-token: write
```

Without `id-token: write`, GitHub Actions does not inject `ACTIONS_ID_TOKEN_REQUEST_TOKEN` or `ACTIONS_ID_TOKEN_REQUEST_URL`, so `google-github-actions/auth@v2` cannot exchange the OIDC token for GCP credentials via Workload Identity Federation. Every job failed immediately on the auth step.

## Test plan
- [ ] Merge and confirm the `Deploy to Test` workflow runs to completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)