### PR TITLE
Fix image URI redacted as job output

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -15,8 +15,6 @@ jobs:
   build-and-push-image:
     name: Build and Push Image
     runs-on: ubuntu-latest
-    outputs:
-      image: ${{ steps.meta.outputs.image }}
     steps:
       - uses: actions/checkout@v4
 
@@ -32,13 +30,10 @@ jobs:
       - name: Configure Docker for Artifact Registry
         run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
 
-      - id: meta
-        run: echo "image=us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/tipical/api:${{ github.sha }}" >> $GITHUB_OUTPUT
-
       - name: Build and push
         run: |
-          docker build -t ${{ steps.meta.outputs.image }} tipical-backend/
-          docker push ${{ steps.meta.outputs.image }}
+          docker build -t us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/tipical/api:${{ github.sha }} tipical-backend/
+          docker push us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/tipical/api:${{ github.sha }}
 
   run-migrations-test:
     name: Run Migrations (Test)
@@ -58,11 +53,11 @@ jobs:
         run: |
           if gcloud run jobs describe tipical-migrate-test --region ${{ env.REGION }} >/dev/null 2>&1; then
             gcloud run jobs update tipical-migrate-test \
-              --image ${{ needs.build-and-push-image.outputs.image }} \
+              --image us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/tipical/api:${{ github.sha }} \
               --region ${{ env.REGION }}
           else
             gcloud run jobs create tipical-migrate-test \
-              --image ${{ needs.build-and-push-image.outputs.image }} \
+              --image us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/tipical/api:${{ github.sha }} \
               --command /app/efbundle \
               --region ${{ env.REGION }} \
               --set-secrets ConnectionStrings__DefaultConnection=test-db-connection-string:latest \
@@ -79,7 +74,7 @@ jobs:
 
   deploy-api-test:
     name: Deploy API (Test)
-    needs: [build-and-push-image, run-migrations-test]
+    needs: run-migrations-test
     runs-on: ubuntu-latest
     environment: test
     outputs:
@@ -98,7 +93,7 @@ jobs:
         id: deploy
         run: |
           gcloud run deploy tipical-api-test \
-            --image ${{ needs.build-and-push-image.outputs.image }} \
+            --image us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/tipical/api:${{ github.sha }} \
             --region ${{ env.REGION }} \
             --add-cloudsql-instances ${{ secrets.GCP_PROJECT_ID }}:${{ env.REGION }}:tipical-db-test \
             --set-secrets "ConnectionStrings__DefaultConnection=test-db-connection-string:latest,GooglePlaces__ApiKey=test-google-places-api-key:latest,GoogleOAuth__ClientId=test-google-oauth-client-id:latest,JwtSettings__Secret=test-jwt-secret:latest" \


### PR DESCRIPTION
Closes #92

GitHub Actions suppresses job outputs that contain secret values. The image URI includes `GCP_PROJECT_ID`, so `needs.build-and-push-image.outputs.image` was always an empty string in downstream jobs — the workflow only appeared to pass because the image already existed in Artifact Registry from a prior run.

## Changes

- Removes the `outputs` block and `meta` step from `build-and-push-image`
- Each job that needs the image URI now reconstructs it inline:
  ```
  us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/tipical/api:${{ github.sha }}
  ```
- Simplifies `deploy-api-test` `needs` from `[build-and-push-image, run-migrations-test]` to just `run-migrations-test` (ordering is already guaranteed transitively)

## Test plan
- [ ] Merge and confirm all five jobs pass on a clean run with no prior image in Artifact Registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)