### PR TITLE
Fix --add-cloudsql-instances not valid for gcloud run jobs

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -61,7 +61,7 @@ jobs:
               --command /app/efbundle \
               --region ${{ env.REGION }} \
               --set-secrets ConnectionStrings__DefaultConnection=test-db-connection-string:latest \
-              --add-cloudsql-instances ${{ secrets.GCP_PROJECT_ID }}:${{ env.REGION }}:tipical-db-test \
+              --set-cloudsql-instances ${{ secrets.GCP_PROJECT_ID }}:${{ env.REGION }}:tipical-db-test \
               --service-account tipical-api-test@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com \
               --max-retries 0
           fi


### PR DESCRIPTION
Closes #95

`--add-cloudsql-instances` is only valid for `gcloud run deploy` (Cloud Run Services). `gcloud run jobs create/update` requires `--set-cloudsql-instances` instead. The flag in the `deploy-api-test` job is unchanged as it correctly uses `gcloud run deploy`.

## Test plan
- [ ] Merge and confirm `run-migrations-test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
