### PR TITLE
Set create_credentials_file: false on jobs without checkout

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          create_credentials_file: false
 
       - uses: google-github-actions/setup-gcloud@v2
         with:
@@ -84,6 +85,7 @@ jobs:
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          create_credentials_file: false
 
       - uses: google-github-actions/setup-gcloud@v2
         with:


### PR DESCRIPTION
Closes #96

`run-migrations-test` and `deploy-api-test` don't check out the repo, so the workspace is empty when `google-github-actions/auth@v2` runs. The default `create_credentials_file: true` causes a warning since there's nowhere to write the file. Both jobs only run `gcloud` commands, which are authenticated via `CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE` set by the action regardless of this option.

## Test plan
- [ ] Merge and confirm the warning no longer appears in either job's logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
