### PR TITLE
Revert "Set create_credentials_file: false on jobs without checkout"

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -44,7 +44,6 @@ jobs:
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
-          create_credentials_file: false
 
       - uses: google-github-actions/setup-gcloud@v2
         with:
@@ -85,7 +84,6 @@ jobs:
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
-          create_credentials_file: false
 
       - uses: google-github-actions/setup-gcloud@v2
         with:


### PR DESCRIPTION
Reverts #98.

Setting `create_credentials_file: false` prevents `google-github-actions/auth@v2` from writing the credentials file and setting `CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE`, which is how `gcloud` authenticates. Without it, gcloud has no active account and all `gcloud` commands fail.

The warning that #96 was trying to suppress ("workspace is empty") is harmless — the credentials file is written to a runner temp path, not the workspace. The warning was misleading.

## Test plan
- [ ] Merge and confirm `run-migrations-test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
