### PR TITLE
Revert inline URI workaround; move GCP_PROJECT_ID to a variable

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -15,6 +15,8 @@ jobs:
   build-and-push-image:
     name: Build and Push Image
     runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
     steps:
       - uses: actions/checkout@v4
 
@@ -30,10 +32,13 @@ jobs:
       - name: Configure Docker for Artifact Registry
         run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
 
+      - id: meta
+        run: echo "image=us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/tipical/api:${{ github.sha }}" >> $GITHUB_OUTPUT
+
       - name: Build and push
         run: |
-          docker build -t us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/tipical/api:${{ github.sha }} tipical-backend/
-          docker push us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/tipical/api:${{ github.sha }}
+          docker build -t ${{ steps.meta.outputs.image }} tipical-backend/
+          docker push ${{ steps.meta.outputs.image }}
 
   run-migrations-test:
     name: Run Migrations (Test)
@@ -53,11 +58,11 @@ jobs:
         run: |
           if gcloud run jobs describe tipical-migrate-test --region ${{ env.REGION }} >/dev/null 2>&1; then
             gcloud run jobs update tipical-migrate-test \
-              --image us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/tipical/api:${{ github.sha }} \
+              --image ${{ needs.build-and-push-image.outputs.image }} \
               --region ${{ env.REGION }}
           else
             gcloud run jobs create tipical-migrate-test \
-              --image us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/tipical/api:${{ github.sha }} \
+              --image ${{ needs.build-and-push-image.outputs.image }} \
               --command /app/efbundle \
               --region ${{ env.REGION }} \
               --set-secrets ConnectionStrings__DefaultConnection=test-db-connection-string:latest \
@@ -74,7 +79,7 @@ jobs:
 
   deploy-api-test:
     name: Deploy API (Test)
-    needs: run-migrations-test
+    needs: [build-and-push-image, run-migrations-test]
     runs-on: ubuntu-latest
     environment: test
     outputs:
@@ -93,7 +98,7 @@ jobs:
         id: deploy
         run: |
           gcloud run deploy tipical-api-test \
-            --image us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/tipical/api:${{ github.sha }} \
+            --image ${{ needs.build-and-push-image.outputs.image }} \
             --region ${{ env.REGION }} \
             --add-cloudsql-instances ${{ secrets.GCP_PROJECT_ID }}:${{ env.REGION }}:tipical-db-test \
             --set-secrets "ConnectionStrings__DefaultConnection=test-db-connection-string:latest,GooglePlaces__ApiKey=test-google-places-api-key:latest,GoogleOAuth__ClientId=test-google-oauth-client-id:latest,JwtSettings__Secret=test-jwt-secret:latest" \

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -27,13 +27,13 @@ jobs:
 
       - uses: google-github-actions/setup-gcloud@v2
         with:
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          project_id: ${{ vars.GCP_PROJECT_ID }}
 
       - name: Configure Docker for Artifact Registry
         run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
 
       - id: meta
-        run: echo "image=us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/tipical/api:${{ github.sha }}" >> $GITHUB_OUTPUT
+        run: echo "image=us-central1-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/tipical/api:${{ github.sha }}" >> $GITHUB_OUTPUT
 
       - name: Build and push
         run: |
@@ -52,7 +52,7 @@ jobs:
 
       - uses: google-github-actions/setup-gcloud@v2
         with:
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          project_id: ${{ vars.GCP_PROJECT_ID }}
 
       - name: Create or update migration job
         run: |
@@ -66,8 +66,8 @@ jobs:
               --command /app/efbundle \
               --region ${{ env.REGION }} \
               --set-secrets ConnectionStrings__DefaultConnection=test-db-connection-string:latest \
-              --set-cloudsql-instances ${{ secrets.GCP_PROJECT_ID }}:${{ env.REGION }}:tipical-db-test \
-              --service-account tipical-api-test@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com \
+              --set-cloudsql-instances ${{ vars.GCP_PROJECT_ID }}:${{ env.REGION }}:tipical-db-test \
+              --service-account tipical-api-test@${{ vars.GCP_PROJECT_ID }}.iam.gserviceaccount.com \
               --max-retries 0
           fi
 
@@ -92,7 +92,7 @@ jobs:
 
       - uses: google-github-actions/setup-gcloud@v2
         with:
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          project_id: ${{ vars.GCP_PROJECT_ID }}
 
       - name: Deploy to Cloud Run
         id: deploy
@@ -100,10 +100,10 @@ jobs:
           gcloud run deploy tipical-api-test \
             --image ${{ needs.build-and-push-image.outputs.image }} \
             --region ${{ env.REGION }} \
-            --add-cloudsql-instances ${{ secrets.GCP_PROJECT_ID }}:${{ env.REGION }}:tipical-db-test \
+            --add-cloudsql-instances ${{ vars.GCP_PROJECT_ID }}:${{ env.REGION }}:tipical-db-test \
             --set-secrets "ConnectionStrings__DefaultConnection=test-db-connection-string:latest,GooglePlaces__ApiKey=test-google-places-api-key:latest,GoogleOAuth__ClientId=test-google-oauth-client-id:latest,JwtSettings__Secret=test-jwt-secret:latest" \
             --set-env-vars "^|^ASPNETCORE_ENVIRONMENT=Production|Cors__AllowedOrigins__0=https://tipical-test.web.app|AllowedUsers__Enabled=${{ vars.ALLOWED_USERS_ENABLED }}|AllowedUsers__Emails=${{ vars.ALLOWED_USERS_EMAILS }}" \
-            --service-account tipical-api-test@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com \
+            --service-account tipical-api-test@${{ vars.GCP_PROJECT_ID }}.iam.gserviceaccount.com \
             --allow-unauthenticated \
             --quiet
 


### PR DESCRIPTION
This PR reverts the inline URI workaround from #94 and replaces it with the proper fix: moving `GCP_PROJECT_ID` from a repository secret to a repository variable.

## Background

GitHub Actions automatically redacts any output that contains a secret value. Since `GCP_PROJECT_ID` was stored as a secret, any job output containing it (the image URI, the Cloud Run service URL) was silently replaced with `***`, causing downstream jobs to receive empty strings.

The workaround in #94 was to inline the image URI everywhere instead of passing it via a job output. This PR reverts that and uses the correct approach instead.

## What changed

- Reverts the inline URI workaround from #94
- Changes all `secrets.GCP_PROJECT_ID` → `vars.GCP_PROJECT_ID` throughout the workflow
- Restores the `image` job output on `build-and-push-image` and the `url` job output on `deploy-api-test`

## Why this is correct

GCP project names are not sensitive — they appear in public URLs, Docker image URIs, and Cloud Run service URLs. Storing one as a secret only causes the redaction problem described above. Repository variables are the right place for non-sensitive configuration.

Closes #92

🤖 Generated with [Claude Code](https://claude.ai/code)
