### PR TITLE
Add AllowedUsers DB table and EF migration

### DIFF
--- a/tipical-backend/src/Tipical.Core/Models/AllowedUser.cs
+++ b/tipical-backend/src/Tipical.Core/Models/AllowedUser.cs
@@ -1,0 +1,8 @@
+namespace Tipical.Core.Models;
+
+public class AllowedUser
+{
+    public Guid Id { get; set; }
+    public string Email { get; set; } = null!;
+    public DateTimeOffset CreatedAt { get; set; }
+}

--- a/tipical-backend/src/Tipical.Infrastructure/Data/ApplicationDbContext.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Data/ApplicationDbContext.cs
@@ -5,6 +5,7 @@ namespace Tipical.Infrastructure.Data;
 
 public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : DbContext(options)
 {
+    public DbSet<AllowedUser> AllowedUsers { get; set; }
     public DbSet<Business> Businesses { get; set; }
     public DbSet<TippingVote> TippingVotes { get; set; }
 

--- a/tipical-backend/src/Tipical.Infrastructure/Data/Configurations/AllowedUserConfiguration.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Data/Configurations/AllowedUserConfiguration.cs
@@ -1,0 +1,31 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Tipical.Core.Models;
+
+namespace Tipical.Infrastructure.Data.Configurations;
+
+public class AllowedUserConfiguration : IEntityTypeConfiguration<AllowedUser>
+{
+    public void Configure(EntityTypeBuilder<AllowedUser> builder)
+    {
+        builder.ToTable("allowed_users");
+
+        builder.HasKey(u => u.Id);
+
+        builder.Property(u => u.Id)
+            .HasColumnName("id")
+            .ValueGeneratedNever();
+
+        builder.Property(u => u.Email)
+            .HasColumnName("email")
+            .HasMaxLength(255)
+            .IsRequired();
+
+        builder.HasIndex(u => u.Email)
+            .IsUnique();
+
+        builder.Property(u => u.CreatedAt)
+            .HasColumnName("created_at")
+            .HasDefaultValueSql("CURRENT_TIMESTAMP");
+    }
+}

--- a/tipical-backend/src/Tipical.Infrastructure/Migrations/20260502043958_AddAllowedUsersTable.Designer.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Migrations/20260502043958_AddAllowedUsersTable.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Tipical.Core.Models;
@@ -12,9 +13,11 @@ using Tipical.Infrastructure.Data;
 namespace Tipical.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260502043958_AddAllowedUsersTable")]
+    partial class AddAllowedUsersTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/tipical-backend/src/Tipical.Infrastructure/Migrations/20260502043958_AddAllowedUsersTable.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Migrations/20260502043958_AddAllowedUsersTable.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tipical.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAllowedUsersTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "allowed_users",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    email = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_allowed_users", x => x.id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_allowed_users_email",
+                table: "allowed_users",
+                column: "email",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "allowed_users");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `AllowedUser` model to `Tipical.Core` with `Id`, `Email` (unique, max 255), and `CreatedAt` (`DateTimeOffset`, server-default)
- Adds `AllowedUserConfiguration` in `Tipical.Infrastructure` following the existing configuration pattern
- Registers `DbSet<AllowedUser>` on `ApplicationDbContext`
- Generates EF Core migration `20260502043958_AddAllowedUsersTable`

Part of #103 (DB layer only; runtime wiring and CI/CD cleanup are follow-up work per the issue)

## Test plan
- [ ] Apply migration against a local Postgres instance and confirm `allowed_users` table is created with the correct schema
- [ ] Confirm `dotnet build` passes
- [ ] Confirm existing tests still pass
