### PR TITLE
Use auto-generated UUIDv7 for AllowedUser.Id

### DIFF
--- a/tipical-backend/src/Tipical.Infrastructure/Data/Configurations/AllowedUserConfiguration.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Data/Configurations/AllowedUserConfiguration.cs
@@ -14,7 +14,8 @@ public class AllowedUserConfiguration : IEntityTypeConfiguration<AllowedUser>
 
         builder.Property(u => u.Id)
             .HasColumnName("id")
-            .ValueGeneratedNever();
+            .ValueGeneratedOnAdd()
+            .HasDefaultValueSql("uuidv7()");
 
         builder.Property(u => u.Email)
             .HasColumnName("email")

--- a/tipical-backend/src/Tipical.Infrastructure/Migrations/20260502053515_AllowedUserUuidV7Default.Designer.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Migrations/20260502053515_AllowedUserUuidV7Default.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Tipical.Core.Models;
@@ -12,9 +13,11 @@ using Tipical.Infrastructure.Data;
 namespace Tipical.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260502053515_AllowedUserUuidV7Default")]
+    partial class AllowedUserUuidV7Default
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/tipical-backend/src/Tipical.Infrastructure/Migrations/20260502053515_AllowedUserUuidV7Default.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Migrations/20260502053515_AllowedUserUuidV7Default.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tipical.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AllowedUserUuidV7Default : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<Guid>(
+                name: "id",
+                table: "allowed_users",
+                type: "uuid",
+                nullable: false,
+                defaultValueSql: "uuidv7()",
+                oldClrType: typeof(Guid),
+                oldType: "uuid");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<Guid>(
+                name: "id",
+                table: "allowed_users",
+                type: "uuid",
+                nullable: false,
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldDefaultValueSql: "uuidv7()");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Updates `AllowedUserConfiguration` to set `ValueGeneratedOnAdd()` and `HasDefaultValueSql("uuidv7()")` on `Id`
- Adds EF Core migration `20260502053515_AllowedUserUuidV7Default` to apply the column default

Part of #105

## Test plan
- [ ] Apply migration and confirm `allowed_users.id` has a `uuidv7()` default in Postgres 19
- [ ] Insert a row without specifying `Id` and confirm a valid UUIDv7 is generated
- [ ] Confirm `dotnet build` passes