### PR TITLE
Check allowed users against DB table instead of config

### DIFF
--- a/tipical-backend/src/Tipical.Api/AllowedUsersOptions.cs
+++ b/tipical-backend/src/Tipical.Api/AllowedUsersOptions.cs
@@ -3,5 +3,4 @@ namespace Tipical.Api;
 public class AllowedUsersOptions
 {
     public bool Enabled { get; set; } = false;
-    public string Emails { get; set; } = string.Empty;
 }

--- a/tipical-backend/src/Tipical.Api/Controllers/AuthController.cs
+++ b/tipical-backend/src/Tipical.Api/Controllers/AuthController.cs
@@ -1,8 +1,10 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using Tipical.Core.DTOs;
 using Tipical.Core.Services;
+using Tipical.Infrastructure.Data;
 
 namespace Tipical.Api.Controllers;
 
@@ -11,6 +13,7 @@ namespace Tipical.Api.Controllers;
 public class AuthController(
     IGoogleAuthService googleAuthService,
     IOptions<AllowedUsersOptions> allowedUsers,
+    ApplicationDbContext dbContext,
     ILogger<AuthController> logger) : ControllerBase
 {
     [HttpPost("google")]
@@ -23,12 +26,14 @@ public class AuthController(
         {
             var response = await googleAuthService.VerifyGoogleTokenAsync(request.IdToken);
 
-            var options = allowedUsers.Value;
-            var emailList = options.Emails.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-            if (options.Enabled && !emailList.Contains(response.Email, StringComparer.OrdinalIgnoreCase))
+            if (allowedUsers.Value.Enabled)
             {
-                logger.LogWarning("Blocked sign-in attempt from non-allowlisted email: {Email}", response.Email);
-                return StatusCode(StatusCodes.Status403Forbidden, new { message = "Access restricted" });
+                var isAllowed = await dbContext.AllowedUsers.AnyAsync(u => EF.Functions.ILike(u.Email, response.Email));
+                if (!isAllowed)
+                {
+                    logger.LogWarning("Blocked sign-in attempt from non-allowlisted email: {Email}", response.Email);
+                    return StatusCode(StatusCodes.Status403Forbidden, new { message = "Access restricted" });
+                }
             }
 
             return Ok(response);

--- a/tipical-backend/src/Tipical.Api/appsettings.json
+++ b/tipical-backend/src/Tipical.Api/appsettings.json
@@ -25,7 +25,6 @@
     "AllowedOrigins": ["http://localhost:5173", "http://localhost:3000"]
   },
   "AllowedUsers": {
-    "Enabled": false,
-    "Emails": ""
+    "Enabled": false
   }
 }


### PR DESCRIPTION
## Summary
- Updates `AuthController` to query the `allowed_users` DB table instead of the `AllowedUsers__Emails` config value
- Removes `AllowedUsersOptions.Emails` and the corresponding `appsettings.json` entry; `AllowedUsers__Enabled` is retained as the feature toggle

Part of #103 (CI/CD cleanup of `vars.ALLOWED_USERS_EMAILS` is tracked separately in the issue)

## Test plan
- [ ] With `AllowedUsers__Enabled=false`: any email can sign in
- [ ] With `AllowedUsers__Enabled=true` and a row in `allowed_users`: the listed email can sign in, unlisted emails get 403
- [ ] Confirm `dotnet build` passes