### PR TITLE
Auto-generate Business.Id in Postgres using uuidv7()

### DIFF
--- a/tipical-backend/src/Tipical.Infrastructure/Data/Configurations/BusinessConfiguration.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Data/Configurations/BusinessConfiguration.cs
@@ -14,7 +14,8 @@ public class BusinessConfiguration : IEntityTypeConfiguration<Business>
 
         builder.Property(b => b.Id)
             .HasColumnName("id")
-            .ValueGeneratedNever();
+            .ValueGeneratedOnAdd()
+            .HasDefaultValueSql("uuidv7()");
 
         builder.Property(b => b.GooglePlaceId)
             .HasColumnName("google_place_id")

--- a/tipical-backend/src/Tipical.Infrastructure/Migrations/20260502061919_BusinessUuidV7Default.Designer.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Migrations/20260502061919_BusinessUuidV7Default.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Tipical.Core.Models;
@@ -12,9 +13,11 @@ using Tipical.Infrastructure.Data;
 namespace Tipical.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260502061919_BusinessUuidV7Default")]
+    partial class BusinessUuidV7Default
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/tipical-backend/src/Tipical.Infrastructure/Migrations/20260502061919_BusinessUuidV7Default.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Migrations/20260502061919_BusinessUuidV7Default.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tipical.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class BusinessUuidV7Default : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<Guid>(
+                name: "id",
+                table: "businesses",
+                type: "uuid",
+                nullable: false,
+                defaultValueSql: "uuidv7()",
+                oldClrType: typeof(Guid),
+                oldType: "uuid");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<Guid>(
+                name: "id",
+                table: "businesses",
+                type: "uuid",
+                nullable: false,
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldDefaultValueSql: "uuidv7()");
+        }
+    }
+}

--- a/tipical-backend/src/Tipical.Infrastructure/Repositories/BusinessRepository.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Repositories/BusinessRepository.cs
@@ -12,14 +12,14 @@ public class BusinessRepository(ApplicationDbContext context) : IBusinessReposit
     {
         return await context.Businesses
             .Include(b => b.TippingVotes)
-            .FirstOrDefaultAsync(b => b.Id == id);
+            .SingleOrDefaultAsync(b => b.Id == id);
     }
 
     public async Task<Business?> GetByGooglePlaceIdAsync(string googlePlaceId)
     {
         return await context.Businesses
             .Include(b => b.TippingVotes)
-            .FirstOrDefaultAsync(b => b.GooglePlaceId == googlePlaceId);
+            .SingleOrDefaultAsync(b => b.GooglePlaceId == googlePlaceId);
     }
 
     public async Task<Dictionary<string, Business>> GetByGooglePlaceIdsAsync(IEnumerable<string> googlePlaceIds)
@@ -32,11 +32,16 @@ public class BusinessRepository(ApplicationDbContext context) : IBusinessReposit
 
     public async Task<Business> GetOrCreateAsync(string googlePlaceId)
     {
-        await context.Upsert(new Business { Id = Guid.NewGuid(), GooglePlaceId = googlePlaceId })
+        var business = await GetByGooglePlaceIdAsync(googlePlaceId);
+        if (business is not null)
+            return business;
+
+        await context.Upsert(new Business { GooglePlaceId = googlePlaceId })
             .On(b => b.GooglePlaceId)
-            .WhenMatched(b => new Business { GooglePlaceId = b.GooglePlaceId })
+            .NoUpdate()
             .RunAsync();
 
-        return await context.Businesses.FirstAsync(b => b.GooglePlaceId == googlePlaceId);
+        return await GetByGooglePlaceIdAsync(googlePlaceId)
+            ?? throw new InvalidOperationException($"Business with GooglePlaceId '{googlePlaceId}' not found after upsert.");
     }
 }


### PR DESCRIPTION
Closes #109.

## Summary
- `BusinessConfiguration`: replace `ValueGeneratedNever()` with `ValueGeneratedOnAdd()` + `HasDefaultValueSql("uuidv7()")`
- `BusinessRepository.GetOrCreateAsync`: remove manual `Id = Guid.NewGuid()` assignment — Postgres now generates the ID
- New EF migration `20260502061919_BusinessUuidV7Default` alters `businesses.id` to add `DEFAULT uuidv7()`

Follows the same pattern used for `AllowedUser.Id` in #106.

## Test plan
- [ ] Run EF migration against local DB and confirm `businesses.id` has a `uuidv7()` default
- [ ] Call the business search endpoint and verify a new business row is created with a valid UUIDv7
- [ ] Verify existing business lookup (by `google_place_id`) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
