### PR TITLE
Auto-generate TippingVote.Id in Postgres using uuidv7()

### DIFF
--- a/tipical-backend/src/Tipical.Infrastructure/Data/Configurations/TippingVoteConfiguration.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Data/Configurations/TippingVoteConfiguration.cs
@@ -14,7 +14,8 @@ public class TippingVoteConfiguration : IEntityTypeConfiguration<TippingVote>
 
         builder.Property(tv => tv.Id)
             .HasColumnName("id")
-            .ValueGeneratedNever();
+            .ValueGeneratedOnAdd()
+            .HasDefaultValueSql("uuidv7()");
 
         builder.Property(tv => tv.BusinessId)
             .HasColumnName("business_id")

--- a/tipical-backend/src/Tipical.Infrastructure/Migrations/20260508170323_TippingVoteUuidV7Default.Designer.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Migrations/20260508170323_TippingVoteUuidV7Default.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Tipical.Core.Models;
@@ -12,9 +13,11 @@ using Tipical.Infrastructure.Data;
 namespace Tipical.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260508170323_TippingVoteUuidV7Default")]
+    partial class TippingVoteUuidV7Default
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/tipical-backend/src/Tipical.Infrastructure/Migrations/20260508170323_TippingVoteUuidV7Default.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Migrations/20260508170323_TippingVoteUuidV7Default.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tipical.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class TippingVoteUuidV7Default : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<Guid>(
+                name: "id",
+                table: "tipping_votes",
+                type: "uuid",
+                nullable: false,
+                defaultValueSql: "uuidv7()",
+                oldClrType: typeof(Guid),
+                oldType: "uuid");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<Guid>(
+                name: "id",
+                table: "tipping_votes",
+                type: "uuid",
+                nullable: false,
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldDefaultValueSql: "uuidv7()");
+        }
+    }
+}

--- a/tipical-backend/src/Tipical.Infrastructure/Repositories/TippingVoteRepository.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Repositories/TippingVoteRepository.cs
@@ -28,7 +28,6 @@ public class TippingVoteRepository(ApplicationDbContext context) : ITippingVoteR
         await context.TippingVotes
             .Upsert(new TippingVote
             {
-                Id = Guid.NewGuid(),
                 BusinessId = businessId,
                 UserId = userId,
                 TippingPolicy = policy,

--- a/tipical-backend/src/Tipical.Infrastructure/Services/BusinessService.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Services/BusinessService.cs
@@ -55,7 +55,6 @@ public class BusinessService(
                 // Placeholder - business not voted on yet
                 var placeholderResponse = new BusinessResponse
                 {
-                    Id = Guid.NewGuid(), // Temporary GUID (not persisted)
                     GooglePlaceId = place.Id,
                     Name = place.DisplayName.Text,
                     Address = place.FormattedAddress,


### PR DESCRIPTION
Closes #111.

## Summary
- `TippingVoteConfiguration`: replace `ValueGeneratedNever()` with `ValueGeneratedOnAdd()` + `HasDefaultValueSql("uuidv7()")`
- `TippingVoteRepository.UpsertAsync`: remove manual `Id = Guid.NewGuid()` assignment — Postgres now generates the ID
- New EF migration `20260508170323_TippingVoteUuidV7Default` alters `tipping_votes.id` to add `DEFAULT uuidv7()`

Follows the same pattern used for `Business.Id` in #110 and `AllowedUser.Id` in #106.

Also cleaned up `BusinessService.Id = Guid.NewGuid()` from the placeholder `BusinessResponse`, as it is no longer needed.

## Test plan
- [ ] Run EF migration against local DB and confirm `tipping_votes.id` has a `uuidv7()` default
- [ ] Submit a tipping vote and verify the row is created with a valid UUIDv7
- [ ] Verify existing vote upsert (updating an existing vote) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
