### PR TITLE
DB-first search: surface voted businesses first, backfill with Google Places

### DIFF
--- a/tipical-backend/src/Tipical.Api/Controllers/TippingController.cs
+++ b/tipical-backend/src/Tipical.Api/Controllers/TippingController.cs
@@ -53,7 +53,8 @@ public class TippingController(ITippingService tippingService, ILogger<TippingCo
             return Unauthorized(new { message = "User ID not found in token" });
         }
 
-        var vote = await tippingService.SubmitVoteAsync(googlePlaceId, userId, request.TippingPolicy);
+        var vote = await tippingService.SubmitVoteAsync(
+            googlePlaceId, userId, request.TippingPolicy, request.Name, request.Latitude, request.Longitude);
         return Ok(vote);
     }
 }

--- a/tipical-backend/src/Tipical.Api/Program.cs
+++ b/tipical-backend/src/Tipical.Api/Program.cs
@@ -21,7 +21,7 @@ builder.Services.AddSwaggerGen();
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseNpgsql(
         builder.Configuration.GetConnectionString("DefaultConnection"),
-        o => o.MapEnum<TippingPolicy>()
+        o => o.MapEnum<TippingPolicy>().UseNetTopologySuite()
     )
 );
 

--- a/tipical-backend/src/Tipical.Core/DTOs/TippingDTOs.cs
+++ b/tipical-backend/src/Tipical.Core/DTOs/TippingDTOs.cs
@@ -4,7 +4,10 @@ namespace Tipical.Core.DTOs;
 
 public class TippingVoteRequest
 {
-    public TippingPolicy TippingPolicy { get; set; }
+    public required TippingPolicy TippingPolicy { get; set; }
+    public required string Name { get; set; }
+    public required double Latitude { get; set; }
+    public required double Longitude { get; set; }
 }
 
 public class TippingVoteResponse

--- a/tipical-backend/src/Tipical.Core/Models/Business.cs
+++ b/tipical-backend/src/Tipical.Core/Models/Business.cs
@@ -1,9 +1,13 @@
+using NetTopologySuite.Geometries;
+
 namespace Tipical.Core.Models;
 
 public class Business
 {
     public Guid Id { get; set; }
     public string GooglePlaceId { get; set; } = null!;
+    public string Name { get; set; } = null!;
+    public Point Location { get; set; } = null!;
 
     // Navigation properties
     public ICollection<TippingVote> TippingVotes { get; set; } = [];

--- a/tipical-backend/src/Tipical.Core/Repositories/IBusinessRepository.cs
+++ b/tipical-backend/src/Tipical.Core/Repositories/IBusinessRepository.cs
@@ -1,3 +1,4 @@
+using NetTopologySuite.Geometries;
 using Tipical.Core.Models;
 
 namespace Tipical.Core.Repositories;
@@ -7,5 +8,6 @@ public interface IBusinessRepository
     Task<Business?> GetByIdAsync(Guid id);
     Task<Business?> GetByGooglePlaceIdAsync(string googlePlaceId);
     Task<Dictionary<string, Business>> GetByGooglePlaceIdsAsync(IEnumerable<string> googlePlaceIds);
-    Task<Business> GetOrCreateAsync(string googlePlaceId);
+    Task<Business> GetOrCreateAsync(string googlePlaceId, string name, Point location);
+    Task<List<Business>> SearchNearbyAsync(double latitude, double longitude, int radiusMeters, int limit);
 }

--- a/tipical-backend/src/Tipical.Core/Services/IGooglePlacesService.cs
+++ b/tipical-backend/src/Tipical.Core/Services/IGooglePlacesService.cs
@@ -4,7 +4,8 @@ namespace Tipical.Core.Services;
 
 public interface IGooglePlacesService
 {
-    Task<SearchTextResponse> SearchAsync(string query, double latitude, double longitude, int radius);
-    Task<SearchNearbyResponse> SearchNearbyAsync(double latitude, double longitude, int radius);
+    Task<SearchTextResponse> SearchAsync(string query, double latitude, double longitude, int radius, int maxResultCount = 20);
+    Task<SearchNearbyResponse> SearchNearbyAsync(double latitude, double longitude, int radius, int maxResultCount = 20);
     Task<AutocompletePlacesResponse> AutocompleteAsync(string input, double latitude, double longitude, int radius);
+    Task<IReadOnlyList<Place>> BulkFetchAsync(IEnumerable<string> placeIds);
 }

--- a/tipical-backend/src/Tipical.Core/Services/ITippingService.cs
+++ b/tipical-backend/src/Tipical.Core/Services/ITippingService.cs
@@ -5,7 +5,7 @@ namespace Tipical.Core.Services;
 
 public interface ITippingService
 {
-    Task<TippingVoteResponse> SubmitVoteAsync(string googlePlaceId, string userId, TippingPolicy policy);
+    Task<TippingVoteResponse> SubmitVoteAsync(string googlePlaceId, string userId, TippingPolicy policy, string name, double latitude, double longitude);
     Task<TippingVotesAggregateResponse> GetVotesAggregateAsync(string googlePlaceId);
     Task<TippingVoteResponse?> GetUserVoteAsync(string googlePlaceId, string userId);
 }

--- a/tipical-backend/src/Tipical.Infrastructure/Data/Configurations/BusinessConfiguration.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Data/Configurations/BusinessConfiguration.cs
@@ -25,6 +25,19 @@ public class BusinessConfiguration : IEntityTypeConfiguration<Business>
         builder.HasIndex(b => b.GooglePlaceId)
             .IsUnique();
 
+        builder.Property(b => b.Name)
+            .HasColumnName("name")
+            .HasMaxLength(500);
+
+        builder.HasIndex(b => b.Name);
+
+        builder.Property(b => b.Location)
+            .HasColumnName("location")
+            .HasColumnType("geography (point)");
+
+        builder.HasIndex(b => b.Location)
+            .HasMethod("GIST");
+
         builder.HasMany(b => b.TippingVotes)
             .WithOne(tv => tv.Business)
             .HasForeignKey(tv => tv.BusinessId)

--- a/tipical-backend/src/Tipical.Infrastructure/Data/GeoConstants.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Data/GeoConstants.cs
@@ -1,0 +1,6 @@
+namespace Tipical.Infrastructure.Data;
+
+internal static class GeoConstants
+{
+    internal const int Wgs84Srid = 4326;
+}

--- a/tipical-backend/src/Tipical.Infrastructure/FieldMaskBuilder.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/FieldMaskBuilder.cs
@@ -1,5 +1,6 @@
 using System.Linq.Expressions;
 using Google.Api.Gax.Grpc;
+using Google.Protobuf.Collections;
 
 namespace Tipical.Infrastructure;
 
@@ -14,9 +15,23 @@ public sealed class FieldMaskRoot<TRoot>
     private readonly List<string> _pathList = [];
 
     public FieldMaskNode<TRoot, TElement> Include<TElement>(
-        Expression<Func<TRoot, IEnumerable<TElement>>> selector)
+        Expression<Func<TRoot, RepeatedField<TElement>>> selector)
     {
         var path = GetMemberName(selector.Body);
+        return new FieldMaskNode<TRoot, TElement>(this, path);
+    }
+
+    public FieldMaskNode<TRoot, TElement> Include<TElement>(Expression<Func<TRoot, TElement>> selector)
+    {
+        if (selector.Body is NewExpression newExpr)
+        {
+            foreach (var arg in newExpr.Arguments)
+                AddPath(GetMemberName(arg));
+            return new FieldMaskNode<TRoot, TElement>(this, string.Empty);
+        }
+
+        var path = GetMemberName(selector.Body);
+        AddPath(path);
         return new FieldMaskNode<TRoot, TElement>(this, path);
     }
 
@@ -70,16 +85,20 @@ public sealed class FieldMaskNode<TRoot, TCurrent>
         if (selector.Body is NewExpression newExpr)
         {
             foreach (var arg in newExpr.Arguments)
-                _root.AddPath($"{_currentPath}.{FieldMaskRoot<TRoot>.GetMemberName(arg)}");
+            {
+                var memberName = FieldMaskRoot<TRoot>.GetMemberName(arg);
+                _root.AddPath(string.IsNullOrEmpty(_currentPath) ? memberName : $"{_currentPath}.{memberName}");
+            }
             return new FieldMaskNode<TRoot, TNext>(_root, _currentPath);
         }
 
         var memberPath = FieldMaskRoot<TRoot>.GetMemberName(selector.Body);
-        return new FieldMaskNode<TRoot, TNext>(_root, $"{_currentPath}.{memberPath}", hasUncommittedPath: true);
+        var path = string.IsNullOrEmpty(_currentPath) ? memberPath : $"{_currentPath}.{memberPath}";
+        return new FieldMaskNode<TRoot, TNext>(_root, path, hasUncommittedPath: true);
     }
 
     public FieldMaskNode<TRoot, TElement> Include<TElement>(
-        Expression<Func<TRoot, IEnumerable<TElement>>> selector)
+        Expression<Func<TRoot, RepeatedField<TElement>>> selector)
     {
         CommitIfNeeded();
         return _root.Include(selector);

--- a/tipical-backend/src/Tipical.Infrastructure/Migrations/20260526232118_AddBusinessLocationAndName.Designer.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Migrations/20260526232118_AddBusinessLocationAndName.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -13,9 +14,11 @@ using Tipical.Infrastructure.Data;
 namespace Tipical.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260526232118_AddBusinessLocationAndName")]
+    partial class AddBusinessLocationAndName
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/tipical-backend/src/Tipical.Infrastructure/Migrations/20260526232118_AddBusinessLocationAndName.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Migrations/20260526232118_AddBusinessLocationAndName.cs
@@ -1,0 +1,69 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using NetTopologySuite.Geometries;
+
+#nullable disable
+
+namespace Tipical.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddBusinessLocationAndName : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterDatabase()
+                .Annotation("Npgsql:Enum:tipping_policy", "no_tips,tips_exclude_tax,tips_include_tax")
+                .Annotation("Npgsql:PostgresExtension:postgis", ",,")
+                .OldAnnotation("Npgsql:Enum:tipping_policy", "no_tips,tips_exclude_tax,tips_include_tax");
+
+            migrationBuilder.AddColumn<Point>(
+                name: "location",
+                table: "businesses",
+                type: "geography (point)",
+                nullable: false);
+
+            migrationBuilder.AddColumn<string>(
+                name: "name",
+                table: "businesses",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: false);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_businesses_location",
+                table: "businesses",
+                column: "location")
+                .Annotation("Npgsql:IndexMethod", "GIST");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_businesses_name",
+                table: "businesses",
+                column: "name");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_businesses_location",
+                table: "businesses");
+
+            migrationBuilder.DropIndex(
+                name: "IX_businesses_name",
+                table: "businesses");
+
+            migrationBuilder.DropColumn(
+                name: "location",
+                table: "businesses");
+
+            migrationBuilder.DropColumn(
+                name: "name",
+                table: "businesses");
+
+            migrationBuilder.AlterDatabase()
+                .Annotation("Npgsql:Enum:tipping_policy", "no_tips,tips_exclude_tax,tips_include_tax")
+                .OldAnnotation("Npgsql:Enum:tipping_policy", "no_tips,tips_exclude_tax,tips_include_tax")
+                .OldAnnotation("Npgsql:PostgresExtension:postgis", ",,");
+        }
+    }
+}

--- a/tipical-backend/src/Tipical.Infrastructure/Repositories/BusinessRepository.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Repositories/BusinessRepository.cs
@@ -1,5 +1,6 @@
 using FlexLabs.EntityFrameworkCore.Upsert;
 using Microsoft.EntityFrameworkCore;
+using NetTopologySuite.Geometries;
 using Tipical.Core.Repositories;
 using Tipical.Core.Models;
 using Tipical.Infrastructure.Data;
@@ -30,13 +31,13 @@ public class BusinessRepository(ApplicationDbContext context) : IBusinessReposit
             .ToDictionaryAsync(b => b.GooglePlaceId, b => b);
     }
 
-    public async Task<Business> GetOrCreateAsync(string googlePlaceId)
+    public async Task<Business> GetOrCreateAsync(string googlePlaceId, string name, Point location)
     {
         var business = await GetByGooglePlaceIdAsync(googlePlaceId);
         if (business is not null)
             return business;
 
-        await context.Upsert(new Business { GooglePlaceId = googlePlaceId })
+        await context.Upsert(new Business { GooglePlaceId = googlePlaceId, Name = name, Location = location })
             .On(b => b.GooglePlaceId)
             .NoUpdate()
             .RunAsync();
@@ -44,4 +45,22 @@ public class BusinessRepository(ApplicationDbContext context) : IBusinessReposit
         return await GetByGooglePlaceIdAsync(googlePlaceId)
             ?? throw new InvalidOperationException($"Business with GooglePlaceId '{googlePlaceId}' not found after upsert.");
     }
+
+    public async Task<List<Business>> SearchNearbyAsync(double latitude, double longitude, int radiusMeters, int limit)
+    {
+        var searchPoint = new Point(longitude, latitude) { SRID = GeoConstants.Wgs84Srid };
+        return await context.Businesses
+            .Where(b => b.Location.IsWithinDistance(searchPoint, radiusMeters))
+            .Include(b => b.TippingVotes)
+            .OrderBy(b =>
+                context.TippingVotes
+                    .Where(v => v.BusinessId == b.Id)
+                    .GroupBy(v => v.TippingPolicy)
+                    .OrderByDescending(g => g.Count())
+                    .Select(g => g.Key)
+                    .First())
+            .Take(limit)
+            .ToListAsync();
+    }
+
 }

--- a/tipical-backend/src/Tipical.Infrastructure/Services/BusinessService.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Services/BusinessService.cs
@@ -8,85 +8,77 @@ namespace Tipical.Infrastructure.Services;
 
 public class BusinessService(
     IBusinessRepository businessRepository,
-    ITippingVoteRepository tippingVoteRepository,
     IGooglePlacesService googlePlacesService) : IBusinessService
 {
+    private const int MaxResults = 20;
+
     public async Task<List<BusinessResponse>> SearchBusinessesAsync(BusinessSearchRequest request)
     {
-        // Search Google Places API — text search when query is provided, nearby search otherwise
-        IEnumerable<Place> places;
-        if (string.IsNullOrWhiteSpace(request.Query))
+        // Step 1: Query DB for known businesses near the requested location, sorted by policy priority
+        var dbBusinesses = await businessRepository.SearchNearbyAsync(
+            request.Latitude, request.Longitude, request.Radius, MaxResults);
+
+        // Step 2: Backfill with Google Places if under the cap
+        var placesById = new Dictionary<string, Place>();
+        IEnumerable<Place> backfillPlaces = [];
+
+        if (dbBusinesses.Count < MaxResults)
         {
-            var nearbyResults = await googlePlacesService.SearchNearbyAsync(
-                request.Latitude,
-                request.Longitude,
-                request.Radius);
-            places = nearbyResults.Places;
-        }
-        else
-        {
-            var textResults = await googlePlacesService.SearchAsync(
-                request.Query,
-                request.Latitude,
-                request.Longitude,
-                request.Radius);
-            places = textResults.Places;
-        }
-
-        // Extract all Google Place IDs
-        var googlePlaceIds = places.Select(p => p.Id).ToList();
-
-        // Single bulk lookup for all businesses
-        var existingBusinesses = await businessRepository.GetByGooglePlaceIdsAsync(googlePlaceIds);
-
-        var businessResponses = new List<BusinessResponse>();
-
-        foreach (var place in places)
-        {
-            // Check if business exists in database (has votes)
-            if (existingBusinesses.TryGetValue(place.Id, out var business))
+            var remaining = MaxResults - dbBusinesses.Count;
+            IEnumerable<Place> places;
+            if (string.IsNullOrWhiteSpace(request.Query))
             {
-                // Business exists - merge Google Places data with vote data
-                var businessResponse = await MapToBusinessResponseAsync(business, place);
-                businessResponses.Add(businessResponse);
+                var result = await googlePlacesService.SearchNearbyAsync(
+                    request.Latitude, request.Longitude, request.Radius,
+                    maxResultCount: MaxResults);
+                places = result.Places;
             }
             else
             {
-                // Placeholder - business not voted on yet
-                var placeholderResponse = new BusinessResponse
-                {
-                    GooglePlaceId = place.Id,
-                    Name = place.DisplayName.Text,
-                    Address = place.FormattedAddress,
-                    Latitude = (decimal)place.Location.Latitude,
-                    Longitude = (decimal)place.Location.Longitude,
-                    PlaceTypes = [.. place.Types_],
-                    Phone = place.InternationalPhoneNumber,
-                    Website = place.WebsiteUri,
-                    WinningPolicy = null, // Indicates placeholder
-                    WinningPolicyVoteCount = null
-                };
-                businessResponses.Add(placeholderResponse);
+                var result = await googlePlacesService.SearchAsync(
+                    request.Query, request.Latitude, request.Longitude, request.Radius,
+                    maxResultCount: MaxResults);
+                places = result.Places;
             }
+
+            placesById = places.ToDictionary(p => p.Id);
+
+            var knownPlaceIds = dbBusinesses.Select(b => b.GooglePlaceId).ToHashSet();
+            backfillPlaces = places
+                .Where(p => !knownPlaceIds.Contains(p.Id))
+                .Take(remaining);
         }
 
-        // Sort by tipping policy ranking (NoTips first, then TipsExcludeTax, then TipsIncludeTax, then Unknown/placeholders)
-        return [.. businessResponses.OrderBy(b => b.WinningPolicy.HasValue ? (int)b.WinningPolicy.Value : 999)];
+        // Step 3: Bulk-fetch any DB businesses not returned by the Places search above
+        var missingFromSearch = dbBusinesses
+            .Where(b => !placesById.ContainsKey(b.GooglePlaceId))
+            .Select(b => b.GooglePlaceId)
+            .ToList();
+        if (missingFromSearch.Count > 0)
+        {
+            var fetched = await googlePlacesService.BulkFetchAsync(missingFromSearch);
+            foreach (var place in fetched)
+                placesById[place.Id] = place;
+        }
+
+        // Step 4: Build responses for DB businesses (already sorted by policy from the query).
+        //         Enrich with Google Places display data when available.
+        var dbResponses = dbBusinesses
+            .Select(b => MapDbBusinessToResponse(b, placesById[b.GooglePlaceId]));
+
+        // Step 5: Append placeholder responses for Google Places backfill
+        var backfillResponses = backfillPlaces.Select(MapPlaceToResponse);
+
+        return [.. dbResponses, .. backfillResponses];
     }
 
-    private async Task<BusinessResponse> MapToBusinessResponseAsync(Business business, Place place)
+    private static BusinessResponse MapDbBusinessToResponse(Business business, Place place)
     {
-        var voteCounts = await tippingVoteRepository.GetVoteCountsByPolicyAsync(business.Id);
-
-        TippingPolicy? winningPolicy = null;
-        int? winningPolicyVoteCount = null;
-
-        if (voteCounts.Count != 0)
-        {
-            var winner = voteCounts.OrderByDescending(kvp => kvp.Value).First();
-            winningPolicy = winner.Key;
-            winningPolicyVoteCount = winner.Value;
-        }
+        var winner = business.TippingVotes
+            .GroupBy(v => v.TippingPolicy)
+            .Select(g => (Policy: g.Key, Count: g.Count()))
+            .OrderByDescending(x => x.Count)
+            .First();
 
         return new BusinessResponse
         {
@@ -99,8 +91,23 @@ public class BusinessService(
             PlaceTypes = [.. place.Types_],
             Phone = !string.IsNullOrWhiteSpace(place.InternationalPhoneNumber) ? place.InternationalPhoneNumber : null,
             Website = !string.IsNullOrWhiteSpace(place.WebsiteUri) ? place.WebsiteUri : null,
-            WinningPolicy = winningPolicy,
-            WinningPolicyVoteCount = winningPolicyVoteCount
+            WinningPolicy = winner.Policy,
+            WinningPolicyVoteCount = winner.Count
         };
     }
+
+    private static BusinessResponse MapPlaceToResponse(Place place) =>
+        new()
+        {
+            GooglePlaceId = place.Id,
+            Name = place.DisplayName.Text,
+            Address = place.FormattedAddress,
+            Latitude = (decimal)place.Location.Latitude,
+            Longitude = (decimal)place.Location.Longitude,
+            PlaceTypes = [.. place.Types_],
+            Phone = !string.IsNullOrWhiteSpace(place.InternationalPhoneNumber) ? place.InternationalPhoneNumber : null,
+            Website = !string.IsNullOrWhiteSpace(place.WebsiteUri) ? place.WebsiteUri : null,
+            WinningPolicy = null,
+            WinningPolicyVoteCount = null
+        };
 }

--- a/tipical-backend/src/Tipical.Infrastructure/Services/GooglePlacesService.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Services/GooglePlacesService.cs
@@ -8,6 +8,11 @@ namespace Tipical.Infrastructure.Services;
 
 public class GooglePlacesService : IGooglePlacesService
 {
+    private static readonly CallSettings GetPlaceSettings =
+        FieldMask.For<Place>()
+            .Include(p => new { p.Id, p.DisplayName, p.FormattedAddress, p.Types_, p.InternationalPhoneNumber, p.WebsiteUri, p.Location })
+            .ToCallSettings();
+
     private static readonly CallSettings NearbySearchSettings =
         FieldMask.For<SearchNearbyResponse>()
             .Include(r => r.Places)
@@ -30,12 +35,12 @@ public class GooglePlacesService : IGooglePlacesService
         }.Build();
     }
 
-    public async Task<SearchTextResponse> SearchAsync(string query, double latitude, double longitude, int radius)
+    public async Task<SearchTextResponse> SearchAsync(string query, double latitude, double longitude, int radius, int maxResultCount = 20)
     {
         return await _client.SearchTextAsync(new SearchTextRequest
         {
             TextQuery = query,
-            MaxResultCount = 20,
+            MaxResultCount = maxResultCount,
             IncludedType = "establishment",
             LocationBias = new SearchTextRequest.Types.LocationBias
             {
@@ -48,11 +53,11 @@ public class GooglePlacesService : IGooglePlacesService
         }, TextSearchSettings);
     }
 
-    public async Task<SearchNearbyResponse> SearchNearbyAsync(double latitude, double longitude, int radius)
+    public async Task<SearchNearbyResponse> SearchNearbyAsync(double latitude, double longitude, int radius, int maxResultCount = 20)
     {
         return await _client.SearchNearbyAsync(new SearchNearbyRequest
         {
-            MaxResultCount = 20,
+            MaxResultCount = maxResultCount,
             IncludedTypes = { "restaurant", "cafe", "coffee_shop", "bar" },
             LocationRestriction = new SearchNearbyRequest.Types.LocationRestriction
             {
@@ -63,6 +68,16 @@ public class GooglePlacesService : IGooglePlacesService
                 }
             }
         }, NearbySearchSettings);
+    }
+
+    public async Task<IReadOnlyList<Place>> BulkFetchAsync(IEnumerable<string> placeIds)
+    {
+        var tasks = placeIds.Select(async id =>
+        {
+            try { return await _client.GetPlaceAsync(new GetPlaceRequest { Name = $"places/{id}" }, GetPlaceSettings); }
+            catch { return null; }
+        });
+        return (await Task.WhenAll(tasks)).Where(p => p != null).Select(p => p!).ToList();
     }
 
     public async Task<AutocompletePlacesResponse> AutocompleteAsync(string input, double latitude, double longitude, int radius)

--- a/tipical-backend/src/Tipical.Infrastructure/Services/TippingService.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Services/TippingService.cs
@@ -1,16 +1,26 @@
+using Microsoft.EntityFrameworkCore;
+using NetTopologySuite.Geometries;
 using Tipical.Core.DTOs;
 using Tipical.Core.Repositories;
 using Tipical.Core.Models;
 using Tipical.Core.Services;
+using Tipical.Infrastructure.Data;
 
 namespace Tipical.Infrastructure.Services;
 
-public class TippingService(ITippingVoteRepository tippingVoteRepository, IBusinessRepository businessRepository) : ITippingService
+public class TippingService(
+    ITippingVoteRepository tippingVoteRepository,
+    IBusinessRepository businessRepository,
+    ApplicationDbContext context) : ITippingService
 {
-    public async Task<TippingVoteResponse> SubmitVoteAsync(string googlePlaceId, string userId, TippingPolicy policy)
+    public async Task<TippingVoteResponse> SubmitVoteAsync(string googlePlaceId, string userId, TippingPolicy policy, string name, double latitude, double longitude)
     {
-        var business = await businessRepository.GetOrCreateAsync(googlePlaceId);
+        var location = new Point(longitude, latitude) { SRID = GeoConstants.Wgs84Srid };
+
+        await using var tx = await context.Database.BeginTransactionAsync();
+        var business = await businessRepository.GetOrCreateAsync(googlePlaceId, name, location);
         var vote = await tippingVoteRepository.UpsertAsync(business.Id, userId, policy);
+        await tx.CommitAsync();
 
         return new TippingVoteResponse
         {

--- a/tipical-backend/tests/Tipical.Infrastructure.Tests/FieldMaskBuilderTests.cs
+++ b/tipical-backend/tests/Tipical.Infrastructure.Tests/FieldMaskBuilderTests.cs
@@ -1,16 +1,18 @@
+using Google.Protobuf.Collections;
+
 namespace Tipical.Infrastructure.Tests;
 
 public class FieldMaskBuilderTests
 {
     private sealed class TestResponse
     {
-        public List<TestItem> Items { get; set; } = [];
+        public RepeatedField<TestItem> Items { get; set; } = [];
         public TestParent Parent { get; set; } = new();
     }
 
     private sealed class TestParent
     {
-        public List<TestItem> Items { get; set; } = [];
+        public RepeatedField<TestItem> Items { get; set; } = [];
     }
 
     private sealed class TestItem
@@ -157,5 +159,27 @@ public class FieldMaskBuilderTests
             .Build();
 
         await Assert.That(mask).IsEqualTo("items.sub.languageCode");
+    }
+
+    [Test]
+    public async Task RootLevelScalarSelection()
+    {
+        var mask = FieldMask.For<TestItem>()
+            .Include(i => new { i.Id, i.Name, i.Types_ })
+            .Build();
+
+        await Assert.That(mask).IsEqualTo("id,name,types");
+    }
+
+    [Test]
+    public async Task ThenInclude_AfterAnonymousTypeInclude_NoLeadingDot()
+    {
+        var mask = FieldMask.For<TestResponse>()
+            .Include(r => new { r.Parent })
+            .ThenInclude(a => a.Parent)
+            .ThenInclude(p => new { p.Items })
+            .Build();
+
+        await Assert.That(mask).IsEqualTo("parent,parent.items");
     }
 }

--- a/tipical-frontend/src/components/business/BusinessDetailPanel.tsx
+++ b/tipical-frontend/src/components/business/BusinessDetailPanel.tsx
@@ -66,7 +66,7 @@ export function BusinessDetailPanel() {
             <h3 className="text-sm font-semibold text-gray-900 uppercase tracking-wide">
               Tipping Policy
             </h3>
-            <TippingPolicyDisplay googlePlaceId={displayBusiness.googlePlaceId} />
+            <TippingPolicyDisplay business={displayBusiness} />
           </div>
 
           <hr className="border-gray-200" />

--- a/tipical-frontend/src/components/map/BusinessMarker.tsx
+++ b/tipical-frontend/src/components/map/BusinessMarker.tsx
@@ -37,8 +37,8 @@ export function BusinessMarker({
   );
 
   const handleClick = useCallback(
-    () => onMarkerClick(business.id),
-    [onMarkerClick, business.id]
+    () => onMarkerClick(business.googlePlaceId),
+    [onMarkerClick, business.googlePlaceId]
   );
 
   const icon = useMemo(

--- a/tipical-frontend/src/components/map/GoogleMap.tsx
+++ b/tipical-frontend/src/components/map/GoogleMap.tsx
@@ -143,9 +143,9 @@ export function GoogleMap({ businesses = [], isSearching = false, initialCenter,
 
         {businesses.map(business => (
           <BusinessMarker
-            key={business.id}
+            key={business.googlePlaceId}
             business={business}
-            isActive={activeMarkerId === business.id}
+            isActive={activeMarkerId === business.googlePlaceId}
             onMarkerClick={handleMarkerClick}
             onInfoWindowClose={handleInfoWindowClose}
           />

--- a/tipical-frontend/src/components/search/SearchResults.tsx
+++ b/tipical-frontend/src/components/search/SearchResults.tsx
@@ -73,7 +73,7 @@ export function SearchResults() {
       {!isLoading && !error && sorted.length > 0 && (
         <ul className="space-y-2">
           {sorted.map(business => (
-            <li key={business.id}>
+            <li key={business.googlePlaceId}>
               <button
                 onClick={() => openBusinessPanel(business)}
                 className="w-full text-left p-3 rounded-lg hover:bg-gray-50 transition-colors border border-gray-100"

--- a/tipical-frontend/src/components/tipping/TippingPolicyDisplay.tsx
+++ b/tipical-frontend/src/components/tipping/TippingPolicyDisplay.tsx
@@ -1,5 +1,5 @@
 import { useTippingData } from '../../hooks';
-import type { TippingPolicy as TippingPolicyType } from '../../types';
+import type { Business, TippingPolicy as TippingPolicyType } from '../../types';
 import { TippingPolicy } from '../../types';
 
 const POLICY_LABELS: Record<TippingPolicyType, string> = {
@@ -15,11 +15,11 @@ const POLICY_BADGE_STYLES: Record<TippingPolicyType, string> = {
 };
 
 interface TippingPolicyDisplayProps {
-  googlePlaceId: string;
+  business: Business;
 }
 
-export function TippingPolicyDisplay({ googlePlaceId }: TippingPolicyDisplayProps) {
-  const { votes, isLoading, error } = useTippingData(googlePlaceId);
+export function TippingPolicyDisplay({ business }: TippingPolicyDisplayProps) {
+  const { votes, isLoading, error } = useTippingData(business);
 
   if (isLoading) {
     return <div className="animate-pulse h-12 bg-gray-100 rounded-lg" />;

--- a/tipical-frontend/src/components/tipping/TippingPolicySelector.tsx
+++ b/tipical-frontend/src/components/tipping/TippingPolicySelector.tsx
@@ -39,7 +39,7 @@ interface TippingPolicySelectorProps {
 export function TippingPolicySelector({ business }: TippingPolicySelectorProps) {
   const isAuthenticated = useAuthStore(s => s.isAuthenticated());
   const setShowAuthModal = useUIStore(s => s.setShowAuthModal);
-  const { userVote, submitVote, isSubmitting, submitError } = useTippingData(business.googlePlaceId);
+  const { userVote, submitVote, isSubmitting, submitError } = useTippingData(business);
 
   const handleVote = (policy: TippingPolicyType) => {
     if (!isAuthenticated) {

--- a/tipical-frontend/src/hooks/useTippingData.ts
+++ b/tipical-frontend/src/hooks/useTippingData.ts
@@ -4,26 +4,26 @@ import { tippingService } from '../services/tippingService';
 import { useAuthStore } from '../stores/authStore';
 import type { Business, TippingVote, TippingVotesAggregate, TippingPolicy } from '../types';
 
-export function useTippingData(googlePlaceId: string | null) {
+export function useTippingData(business: Business) {
+  const { googlePlaceId } = business;
   const queryClient = useQueryClient();
   const isAuthenticated = useAuthStore(s => s.isAuthenticated());
 
   const votesQuery = useQuery<TippingVotesAggregate>({
     queryKey: ['tipping', 'votes', googlePlaceId],
-    queryFn: () => tippingService.getVotes(googlePlaceId!),
-    enabled: Boolean(googlePlaceId),
+    queryFn: () => tippingService.getVotes(googlePlaceId),
   });
 
   const userVoteQuery = useQuery<TippingVote | null>({
     queryKey: ['tipping', 'userVote', googlePlaceId],
-    queryFn: () => tippingService.getUserVote(googlePlaceId!),
-    enabled: Boolean(googlePlaceId) && isAuthenticated,
+    queryFn: () => tippingService.getUserVote(googlePlaceId),
+    enabled: isAuthenticated,
   });
 
   // Mirror the latest aggregate into every business search cache entry so map
   // pins reflect the current winning policy without a separate search refetch.
   useEffect(() => {
-    if (!votesQuery.data || !googlePlaceId) return;
+    if (!votesQuery.data) return;
     const { winningPolicy, winningPolicyVoteCount } = votesQuery.data;
     queryClient.setQueriesData<Business[]>(
       { queryKey: ['businesses', 'search'], exact: false },
@@ -38,7 +38,12 @@ export function useTippingData(googlePlaceId: string | null) {
 
   const submitVoteMutation = useMutation<TippingVote, Error, TippingPolicy>({
     mutationFn: (policy) =>
-      tippingService.submitVote(googlePlaceId!, { tippingPolicy: policy }),
+      tippingService.submitVote(googlePlaceId, {
+        tippingPolicy: policy,
+        name: business.name,
+        latitude: business.latitude,
+        longitude: business.longitude,
+      }),
     onSuccess: (data) => {
       queryClient.setQueryData(['tipping', 'userVote', googlePlaceId], data);
       queryClient.invalidateQueries({ queryKey: ['tipping', 'votes', googlePlaceId] });
@@ -50,10 +55,7 @@ export function useTippingData(googlePlaceId: string | null) {
     userVote: userVoteQuery.data ?? null,
     isLoading: votesQuery.isLoading || userVoteQuery.isLoading,
     error: votesQuery.error ?? userVoteQuery.error,
-    submitVote: (policy: TippingPolicy) => {
-      if (!googlePlaceId) return;
-      submitVoteMutation.mutate(policy);
-    },
+    submitVote: (policy: TippingPolicy) => submitVoteMutation.mutate(policy),
     isSubmitting: submitVoteMutation.isPending,
     submitError: submitVoteMutation.error,
   };

--- a/tipical-frontend/src/types/index.ts
+++ b/tipical-frontend/src/types/index.ts
@@ -57,4 +57,7 @@ export interface GoogleAuthRequest {
 
 export interface TippingVoteRequest {
   tippingPolicy: TippingPolicy;
+  name: string;
+  latitude: number;
+  longitude: number;
 }


### PR DESCRIPTION
Closes #114

## Summary

- Add `name` (varchar 500, non-nullable, indexed) and `location` (geography point, non-nullable, spatial GIST index) columns to `businesses` table via a new migration
- `BusinessRepository.SearchNearbyAsync` — PostGIS `ST_DWithin` (via NTS `IsWithinDistance`) within the requested radius, sorted by winning tipping policy using a correlated subquery on `TippingVotes` so Postgres does the ordering
- `BusinessRepository.GetOrCreateAsync` — updated to accept `name` and `location`; persists them on creation (`NoUpdate`, so existing records are not overwritten);
- `TippingService.SubmitVoteAsync` — calls `GetOrCreateAsync` (single round trip)
- `BusinessService` — rewritten search orchestration:
  - Query DB first (up to 20); always request the full 20 from Google Places regardless of DB count, to account for result overlap
  - Bulk-fetch any DB businesses not returned by the Places search (via new `IGooglePlacesService.BulkFetchAsync`) so every DB result is always enriched with live Places data
  - Backfill with remaining Places results up to the cap; append after DB results
- `IGooglePlacesService.BulkFetchAsync` — parallel `GetPlaceAsync` calls via `Task.WhenAll`; field mask set via `FieldMaskBuilder`
- `FieldMaskBuilder` — new `Include<TElement>(Expression<Func<TRoot, TElement>>)` overload for root-level scalar/anonymous-type field selection (complements the existing `RepeatedField<TElement>` overload); unit test added
- `GeoConstants` — shared `Wgs84Srid` constant in `Infrastructure/Data/`, used by both `BusinessRepository` and `TippingService`
- `Program.cs` — add `UseNetTopologySuite()` to Npgsql DbContext options
- Search result list and map markers use `googlePlaceId` as the React key (stable and unique across both DB-backed and backfill results)

## Test plan

- [x] Run migration against local DB: `dotnet ef database update`
- [x] Search an area with no voted businesses → result is pure Google Places backfill (≤ 20)
- [x] Vote on a business, search the same area → voted business appears first, sorted above unvoted ones
- [ ] Vote on 20+ businesses in an area → Google Places backfill is skipped, all results come from DB
- [ ] Verify all DB businesses have live Places data (name, address, phone, types) — no empty-address results
