### PR TITLE
Fix TypeScript build failure: TippingPolicySelector business prop too narrow

### DIFF
--- a/tipical-frontend/src/components/tipping/TippingPolicySelector.tsx
+++ b/tipical-frontend/src/components/tipping/TippingPolicySelector.tsx
@@ -33,7 +33,7 @@ const POLICY_OPTIONS: PolicyOption[] = [
 ];
 
 interface TippingPolicySelectorProps {
-  business: Pick<Business, 'googlePlaceId'>;
+  business: Business;
 }
 
 export function TippingPolicySelector({ business }: TippingPolicySelectorProps) {


### PR DESCRIPTION
Fixes #117

## Summary
- `TippingPolicySelectorProps.business` was typed as `Pick<Business, 'googlePlaceId'>`, but `useTippingData` requires a full `Business` — it accesses `name`, `latitude`, and `longitude` in the `submitVote` mutation payload
- The narrowed `Pick` was incorrect and unnecessary; `BusinessDetailPanel` always passes a full `Business`
- Changed the prop type to `Business`

## Test plan
- [ ] TypeScript build passes (`tsc -b`)
- [ ] Deployment pipeline succeeds
