### PR TITLE
Fix vote button not updating on first click after changing vote

### DIFF
--- a/tipical-backend/src/Tipical.Infrastructure/Repositories/TippingVoteRepository.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Repositories/TippingVoteRepository.cs
@@ -42,8 +42,11 @@ public class TippingVoteRepository(ApplicationDbContext context) : ITippingVoteR
             })
             .RunAsync();
 
-        // Retrieve the upserted vote to return
-        var vote = await GetByBusinessAndUserAsync(businessId, userId);
+        // AsNoTracking bypasses EF Core identity map, ensuring the freshly-upserted
+        // row is returned rather than a stale tracked entity loaded earlier in the request.
+        var vote = await context.TippingVotes
+            .AsNoTracking()
+            .FirstOrDefaultAsync(tv => tv.BusinessId == businessId && tv.UserId == userId);
         return vote!;
     }
 


### PR DESCRIPTION
## Summary

- After a user changes an existing vote, the selected button now immediately reflects the new vote
- Root cause: `GetOrCreateAsync` eagerly loads `TippingVotes` via `Include`, putting the old vote entity into EF Core's identity map; the subsequent re-read in `UpsertAsync` resolved against that stale tracked entity instead of the freshly-upserted DB row
- Fix: use `AsNoTracking()` when re-reading the vote after the upsert so EF Core materializes directly from the DB rather than the identity map

Closes #116

## Test plan

- [ ] Cast an initial vote on a business
- [ ] Change your vote to a different policy — the newly-selected button should highlight immediately on the first click
- [ ] Confirm aggregate vote counts and map pin also update correctly
- [ ] Verify first-time voting (insert path) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
