### PR TITLE
Wire VITE_GOOGLE_MAPS_MAP_ID into deploy-test workflow

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -134,6 +134,7 @@ jobs:
         env:
           VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL }}
           VITE_GOOGLE_MAPS_API_KEY: ${{ vars.VITE_GOOGLE_MAPS_API_KEY }}
+          VITE_GOOGLE_MAPS_MAP_ID: ${{ vars.VITE_GOOGLE_MAPS_MAP_ID }}
           VITE_GOOGLE_OAUTH_CLIENT_ID: ${{ vars.VITE_GOOGLE_OAUTH_CLIENT_ID }}
 
       - uses: google-github-actions/auth@v3


### PR DESCRIPTION
Closes #76

## Summary

- Adds `VITE_GOOGLE_MAPS_MAP_ID` to the frontend build step in `deploy-test.yml`, sourced from the `VITE_GOOGLE_MAPS_MAP_ID` repository variable (already added to the test environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
