### PR TITLE
Fix invalid IncludedType in GooglePlacesService.SearchAsync

### DIFF
--- a/tipical-backend/src/Tipical.Infrastructure/Services/GooglePlacesService.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Services/GooglePlacesService.cs
@@ -41,7 +41,7 @@ public class GooglePlacesService : IGooglePlacesService
         {
             TextQuery = query,
             MaxResultCount = maxResultCount,
-            IncludedType = "establishment",
+            IncludedType = "restaurant",
             LocationBias = new SearchTextRequest.Types.LocationBias
             {
                 Circle = new Circle


### PR DESCRIPTION
Fixes #131

## Summary

`SearchAsync` was passing `IncludedType = "establishment"` to the Places API text search request. `"establishment"` is not a valid type for this field — the API rejects it outright, causing a 500 on any text search.

Changed to `"restaurant"`, which is a valid type and consistent with the types already used in `SearchNearbyAsync`.

## Test plan

- [x] Perform a keyword search (e.g. "pizza") in the app and confirm results are returned without a 500
- [x] Confirm returned places are food/drink establishments as expected
