### PR TITLE
Add Places API autocomplete to business search with smart map pan/zoom

### DIFF
--- a/tipical-backend/src/Tipical.Api/Controllers/BusinessesController.cs
+++ b/tipical-backend/src/Tipical.Api/Controllers/BusinessesController.cs
@@ -8,15 +8,31 @@ namespace Tipical.Api.Controllers;
 [Route("api/v1/businesses")]
 public class BusinessesController(IBusinessService businessService, ILogger<BusinessesController> logger) : ControllerBase
 {
-    /// <summary>Search for businesses near a location.</summary>
-    /// <param name="query">Optional name or keyword filter.</param>
-    /// <param name="latitude">Center latitude of the search area.</param>
-    /// <param name="longitude">Center longitude of the search area.</param>
-    /// <param name="radius">Search radius in meters.</param>
+    /// <summary>Search for businesses near a location, or look up a single place by ID.</summary>
+    /// <param name="placeId">Google Place ID for a direct place lookup (from autocomplete selection).</param>
+    /// <param name="sessionToken">Autocomplete session token to close the billing session when using placeId.</param>
+    /// <param name="query">Optional name or keyword filter (used when placeId is absent).</param>
+    /// <param name="latitude">Center latitude of the search area (used when placeId is absent).</param>
+    /// <param name="longitude">Center longitude of the search area (used when placeId is absent).</param>
+    /// <param name="radius">Search radius in meters (used when placeId is absent).</param>
     [HttpGet("search")]
     [ProducesResponseType(typeof(List<BusinessResponse>), StatusCodes.Status200OK)]
-    public async Task<ActionResult<List<BusinessResponse>>> Search([FromQuery] string? query, [FromQuery] double latitude, [FromQuery] double longitude, [FromQuery] int radius)
+    public async Task<ActionResult<List<BusinessResponse>>> Search(
+        [FromQuery] string? placeId,
+        [FromQuery] string? sessionToken,
+        [FromQuery] string? query,
+        [FromQuery] double latitude,
+        [FromQuery] double longitude,
+        [FromQuery] int radius)
     {
+        if (!string.IsNullOrWhiteSpace(placeId))
+        {
+            if (string.IsNullOrWhiteSpace(sessionToken))
+                return BadRequest("sessionToken is required when placeId is provided.");
+            var result = await businessService.PlaceDetailSearchAsync(placeId, sessionToken);
+            return Ok(result);
+        }
+
         var request = new BusinessSearchRequest
         {
             Query = query,

--- a/tipical-backend/src/Tipical.Core/Services/IBusinessService.cs
+++ b/tipical-backend/src/Tipical.Core/Services/IBusinessService.cs
@@ -5,4 +5,5 @@ namespace Tipical.Core.Services;
 public interface IBusinessService
 {
     Task<List<BusinessResponse>> SearchBusinessesAsync(BusinessSearchRequest request);
+    Task<List<BusinessResponse>> PlaceDetailSearchAsync(string placeId, string sessionToken);
 }

--- a/tipical-backend/src/Tipical.Core/Services/IGooglePlacesService.cs
+++ b/tipical-backend/src/Tipical.Core/Services/IGooglePlacesService.cs
@@ -7,5 +7,6 @@ public interface IGooglePlacesService
     Task<SearchTextResponse> SearchAsync(string query, double latitude, double longitude, int radius, int maxResultCount = 20);
     Task<SearchNearbyResponse> SearchNearbyAsync(double latitude, double longitude, int radius, int maxResultCount = 20);
     Task<AutocompletePlacesResponse> AutocompleteAsync(string input, double latitude, double longitude, int radius);
+    Task<Place> GetPlaceAsync(string placeId, string sessionToken);
     Task<IReadOnlyList<Place>> BulkFetchAsync(IEnumerable<string> placeIds);
 }

--- a/tipical-backend/src/Tipical.Infrastructure/Services/BusinessService.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Services/BusinessService.cs
@@ -1,4 +1,5 @@
 using Google.Maps.Places.V1;
+using Grpc.Core;
 using Tipical.Core.DTOs;
 using Tipical.Core.Repositories;
 using Tipical.Core.Models;
@@ -11,6 +12,19 @@ public class BusinessService(
     IGooglePlacesService googlePlacesService) : IBusinessService
 {
     private const int MaxResults = 20;
+
+    public async Task<List<BusinessResponse>> PlaceDetailSearchAsync(string placeId, string sessionToken)
+    {
+        Place place;
+        try { place = await googlePlacesService.GetPlaceAsync(placeId, sessionToken); }
+        catch (RpcException) { return []; }
+
+        var businessByPlaceId = await businessRepository.GetByGooglePlaceIdsAsync([placeId]);
+        var response = businessByPlaceId.TryGetValue(placeId, out var business)
+            ? MapDbBusinessToResponse(business, place)
+            : MapPlaceToResponse(place);
+        return [response];
+    }
 
     public Task<List<BusinessResponse>> SearchBusinessesAsync(BusinessSearchRequest request) =>
         string.IsNullOrWhiteSpace(request.Query)

--- a/tipical-backend/src/Tipical.Infrastructure/Services/GooglePlacesService.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Services/GooglePlacesService.cs
@@ -69,6 +69,13 @@ public class GooglePlacesService : IGooglePlacesService
         }, NearbySearchSettings);
     }
 
+    public async Task<Place> GetPlaceAsync(string placeId, string sessionToken)
+    {
+        return await _client.GetPlaceAsync(
+            new GetPlaceRequest { Name = $"places/{placeId}", SessionToken = sessionToken },
+            GetPlaceSettings);
+    }
+
     public async Task<IReadOnlyList<Place>> BulkFetchAsync(IEnumerable<string> placeIds)
     {
         var tasks = placeIds.Select(async id =>

--- a/tipical-frontend/src/App.tsx
+++ b/tipical-frontend/src/App.tsx
@@ -19,13 +19,15 @@ interface AppLayoutProps {
 }
 
 function AppLayout({ initialCenter, initialZoom }: AppLayoutProps) {
-  const { searchCenter, query } = useSearchStore(
-    useShallow(s => ({ searchCenter: s.searchCenter, query: s.query }))
+  const { searchCenter, query, placeId, sessionToken } = useSearchStore(
+    useShallow(s => ({ searchCenter: s.searchCenter, query: s.query, placeId: s.placeId, sessionToken: s.sessionToken }))
   );
 
   const { data: businesses = [], isLoading, isPlaceholderData } = useBusinessSearch({
     query,
     searchCenter,
+    placeId,
+    sessionToken,
   });
 
   return (

--- a/tipical-frontend/src/components/map/GoogleMap.tsx
+++ b/tipical-frontend/src/components/map/GoogleMap.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Map, AdvancedMarker, MapControl, ControlPosition, useMap } from '@vis.gl/react-google-maps';
 import { useUIStore } from '../../stores/uiStore';
+import { useSearchStore } from '../../stores/searchStore';
 import { useGeolocation } from '../../hooks';
 import type { Business } from '../../types';
 import { BusinessMarker } from './BusinessMarker';
@@ -16,6 +17,37 @@ interface GoogleMapProps {
   initialZoom: number;
   searchBarSlot?: React.ReactNode;
   userProfileSlot?: React.ReactNode;
+}
+
+function MapController({ businesses }: { businesses: Business[] }) {
+  const map = useMap();
+  const fitBoundsOnResults = useSearchStore(s => s.fitBoundsOnResults);
+  const clearFitBounds = useSearchStore(s => s.clearFitBounds);
+  const syncButtonBase = useSearchStore(s => s.syncButtonBase);
+
+  const fitBoundsRef = useRef(fitBoundsOnResults);
+  fitBoundsRef.current = fitBoundsOnResults;
+
+  useEffect(() => {
+    if (!map || !fitBoundsRef.current || !businesses.length) return;
+    clearFitBounds();
+    const bounds = new google.maps.LatLngBounds();
+    businesses.forEach(b => bounds.extend({ lat: b.latitude, lng: b.longitude }));
+    map.fitBounds(bounds, 80);
+
+    const listener = map.addListener('idle', () => {
+      listener.remove();
+      const c = map.getCenter();
+      const z = map.getZoom();
+      if (c && z !== undefined) {
+        syncButtonBase({ latitude: c.lat(), longitude: c.lng(), zoom: z });
+      }
+    });
+
+    return () => listener.remove();
+  }, [businesses, map, clearFitBounds, syncButtonBase]);
+
+  return null;
 }
 
 // Inner component — uses useMap() which requires being inside <Map>'s React tree
@@ -141,6 +173,7 @@ export function GoogleMap({ businesses = [], isSearching = false, initialCenter,
         }}
         onClick={handleMapClick}
       >
+        <MapController businesses={businesses} />
         {latitude !== null && longitude !== null && (
           <>
             <MapPanner latitude={latitude} longitude={longitude} />

--- a/tipical-frontend/src/components/map/SearchThisAreaButton.tsx
+++ b/tipical-frontend/src/components/map/SearchThisAreaButton.tsx
@@ -9,8 +9,10 @@ interface SearchThisAreaButtonProps {
 
 export function SearchThisAreaButton({ center, zoom, isSearching = false }: SearchThisAreaButtonProps) {
   const setSearchCenter = useSearchStore(s => s.setSearchCenter);
+  const placeId = useSearchStore(s => s.placeId);
   const visible = useSearchAreaChanged(center, zoom);
 
+  if (placeId) return null;
   if (!visible && !isSearching) return null;
 
   return (

--- a/tipical-frontend/src/components/search/SearchBar.tsx
+++ b/tipical-frontend/src/components/search/SearchBar.tsx
@@ -1,32 +1,213 @@
-import { useState } from 'react';
+import { useState, useRef, useCallback, useEffect } from 'react';
+import { useMap } from '@vis.gl/react-google-maps';
 import { useSearchStore } from '../../stores/searchStore';
+import { useClickOutside } from '../../hooks/useClickOutside';
+import { radiusFromZoom } from '../../utils/geo';
+import { useDebounce } from '../../hooks/useDebounce';
+
+interface SuggestionListProps {
+  suggestions: google.maps.places.AutocompleteSuggestion[];
+  activeIndex: number;
+  onSelect: (suggestion: google.maps.places.AutocompleteSuggestion) => void;
+  onHover: (index: number) => void;
+}
+
+function SuggestionList({ suggestions, activeIndex, onSelect, onHover }: SuggestionListProps) {
+  if (!suggestions.length) return null;
+  return (
+    <ul
+      role="listbox"
+      className="absolute top-full left-0 right-0 mt-1 bg-white rounded-xl shadow-lg py-1 z-50 overflow-hidden"
+    >
+      {suggestions.map((suggestion, index) => {
+        const prediction = suggestion.placePrediction;
+        if (!prediction) return null;
+        return (
+          <li
+            key={prediction.placeId}
+            id={`suggestion-${index}`}
+            role="option"
+            aria-selected={index === activeIndex}
+            onMouseDown={() => onSelect(suggestion)}
+            onMouseEnter={() => onHover(index)}
+            className={`px-4 py-2.5 cursor-pointer text-sm ${
+              index === activeIndex ? 'bg-gray-100' : 'hover:bg-gray-50'
+            }`}
+          >
+            <span className="font-medium text-gray-900">{prediction.mainText!.text}</span>
+            {prediction.secondaryText?.text && (
+              <span className="text-gray-500 ml-1.5">{prediction.secondaryText.text}</span>
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+// AutocompleteSessionToken accepts a UUID string at runtime; TS types omit this constructor arg
+function newAutocompleteSessionToken(uuid: string): google.maps.places.AutocompleteSessionToken {
+  return new (google.maps.places.AutocompleteSessionToken as unknown as new (token: string) => google.maps.places.AutocompleteSessionToken)(uuid);
+}
 
 export function SearchBar() {
   const [inputValue, setInputValue] = useState('');
-  const setQuery = useSearchStore(s => s.setQuery);
+  const [suggestions, setSuggestions] = useState<google.maps.places.AutocompleteSuggestion[]>([]);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const sessionTokenRef = useRef<string | null>(null);
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const setQuery = useSearchStore(s => s.setQuery);
+  const setPlaceId = useSearchStore(s => s.setPlaceId);
+  const setSearchCenter = useSearchStore(s => s.setSearchCenter);
+  const clearSearch = useSearchStore(s => s.clearSearch);
+  const placeId = useSearchStore(s => s.placeId);
+  const map = useMap();
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const debouncedInput = useDebounce(inputValue, 300);
+
+  useClickOutside(containerRef, () => {
+    setSuggestions([]);
+    setActiveIndex(-1);
+  });
+
+  const startSession = useCallback(() => {
+    if (!sessionTokenRef.current) {
+      sessionTokenRef.current = crypto.randomUUID();
+    }
+  }, []);
+
+  const resetSession = useCallback(() => {
+    sessionTokenRef.current = null;
+  }, []);
+
+  useEffect(() => {
+    const trimmed = debouncedInput.trim();
+    if (!trimmed || !sessionTokenRef.current || !map) {
+      setSuggestions([]);
+      return;
+    }
+
+    const center = map.getCenter()!;
+    const radius = radiusFromZoom(map.getZoom()!);
+
+    let cancelled = false;
+
+    google.maps.places.AutocompleteSuggestion.fetchAutocompleteSuggestions({
+      input: trimmed,
+      sessionToken: newAutocompleteSessionToken(sessionTokenRef.current!),
+      locationBias: {
+        center: { lat: center.lat(), lng: center.lng() },
+        radius,
+      },
+    }).then(({ suggestions: s }) => {
+      if (!cancelled) { setSuggestions(s); setActiveIndex(-1); }
+    }).catch(() => {
+      if (!cancelled) setSuggestions([]);
+    });
+
+    return () => { cancelled = true; };
+  }, [debouncedInput, map]);
+
+  const selectSuggestion = useCallback((suggestion: google.maps.places.AutocompleteSuggestion) => {
+    const prediction = suggestion.placePrediction;
+    if (!prediction || !sessionTokenRef.current) return;
+
+    const displayText = prediction.mainText!.text;
+    setInputValue(displayText);
+    setSuggestions([]);
+    setActiveIndex(-1);
+    setPlaceId(prediction.placeId, displayText, sessionTokenRef.current);
+    resetSession();
+  }, [setPlaceId, resetSession]);
+
+  const handleClear = useCallback(() => {
+    setInputValue('');
+    setSuggestions([]);
+    setActiveIndex(-1);
+    resetSession();
+    const center = map!.getCenter()!;
+    clearSearch({ latitude: center.lat(), longitude: center.lng(), zoom: map!.getZoom()! });
+  }, [map, clearSearch, resetSession]);
+
+  const handleSubmit = useCallback((e: React.FormEvent) => {
     e.preventDefault();
+    setSuggestions([]);
+    setActiveIndex(-1);
+    resetSession();
+    const center = map!.getCenter()!;
+    setSearchCenter({ latitude: center.lat(), longitude: center.lng(), zoom: map!.getZoom()! });
     setQuery(inputValue);
-  };
+  }, [inputValue, map, setSearchCenter, setQuery, resetSession]);
+
+  const handleInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setInputValue(value);
+    if (value.trim()) {
+      startSession();
+    } else {
+      setSuggestions([]);
+      setActiveIndex(-1);
+      resetSession();
+    }
+  }, [startSession, resetSession]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (!suggestions.length) return;
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActiveIndex(prev => Math.min(prev + 1, suggestions.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActiveIndex(prev => Math.max(prev - 1, -1));
+    } else if (e.key === 'Escape') {
+      setSuggestions([]);
+      setActiveIndex(-1);
+    } else if (e.key === 'Enter' && activeIndex >= 0) {
+      e.preventDefault();
+      selectSuggestion(suggestions[activeIndex]);
+    }
+  }, [suggestions, activeIndex, selectSuggestion]);
 
   return (
-    <form
-      onSubmit={handleSubmit}
-      className="flex items-center gap-2 bg-white rounded-xl shadow-lg px-4 py-2 w-full max-w-xl"
-    >
-      <button type="submit" aria-label="Search" className="flex-shrink-0">
-        <svg className="w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-        </svg>
-      </button>
-      <input
-        type="text"
-        value={inputValue}
-        onChange={e => setInputValue(e.target.value)}
-        placeholder="Search businesses..."
-        className="flex-1 outline-none text-sm text-gray-900 placeholder-gray-400"
+    <div ref={containerRef} className="relative w-full max-w-xl">
+      <form
+        onSubmit={handleSubmit}
+        className="flex items-center gap-2 bg-white rounded-xl shadow-lg px-4 py-2"
+      >
+        <button type="submit" aria-label="Search" className="flex-shrink-0">
+          <svg className="w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+          </svg>
+        </button>
+        <input
+          type="text"
+          value={inputValue}
+          onChange={handleInputChange}
+          onKeyDown={handleKeyDown}
+          placeholder="Search businesses..."
+          className="flex-1 outline-none text-sm text-gray-900 placeholder-gray-400"
+          autoComplete="off"
+          role="combobox"
+          aria-expanded={suggestions.length > 0}
+          aria-autocomplete="list"
+          aria-activedescendant={activeIndex >= 0 ? `suggestion-${activeIndex}` : undefined}
+        />
+        {(inputValue || placeId) && (
+          <button type="button" onClick={handleClear} aria-label="Clear search" className="flex-shrink-0">
+            <svg className="w-4 h-4 text-gray-400 hover:text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        )}
+      </form>
+      <SuggestionList
+        suggestions={suggestions}
+        activeIndex={activeIndex}
+        onSelect={selectSuggestion}
+        onHover={setActiveIndex}
       />
-    </form>
+    </div>
   );
 }

--- a/tipical-frontend/src/hooks/useBusinessSearch.ts
+++ b/tipical-frontend/src/hooks/useBusinessSearch.ts
@@ -7,17 +7,24 @@ import type { Business } from '../types';
 interface UseBusinessSearchOptions {
   query?: string;
   searchCenter: SearchCenter;
+  placeId?: string | null;
+  sessionToken?: string | null;
 }
 
-export function useBusinessSearch({ query, searchCenter }: UseBusinessSearchOptions) {
+export function useBusinessSearch({ query, searchCenter, placeId, sessionToken }: UseBusinessSearchOptions) {
   const normalizedQuery = query?.trim() || undefined;
   const radius = radiusFromZoom(searchCenter.zoom);
   const roundedLat = Math.round(searchCenter.latitude * 1e4) / 1e4;
   const roundedLng = Math.round(searchCenter.longitude * 1e4) / 1e4;
 
   return useQuery<Business[]>({
-    queryKey: ['businesses', 'search', { query: normalizedQuery, latitude: roundedLat, longitude: roundedLng, radius }],
-    queryFn: () => businessService.search(normalizedQuery, searchCenter.latitude, searchCenter.longitude, radius),
+    queryKey: placeId
+      ? ['businesses', 'place', placeId, sessionToken]
+      : ['businesses', 'search', { query: normalizedQuery, latitude: roundedLat, longitude: roundedLng, radius }],
+    queryFn: () =>
+      placeId
+        ? businessService.searchByPlaceId(placeId, sessionToken!)
+        : businessService.search(normalizedQuery, searchCenter.latitude, searchCenter.longitude, radius),
     placeholderData: keepPreviousData,
   });
 }

--- a/tipical-frontend/src/hooks/useSearchAreaChanged.ts
+++ b/tipical-frontend/src/hooks/useSearchAreaChanged.ts
@@ -2,11 +2,11 @@ import { useSearchStore } from '../stores/searchStore';
 import { haversineDistance, radiusFromZoom } from '../utils/geo';
 
 export function useSearchAreaChanged(center: { lat: number; lng: number }, zoom: number): boolean {
-  const searchCenter = useSearchStore(s => s.searchCenter);
+  const buttonBaseCenter = useSearchStore(s => s.buttonBaseCenter);
 
-  const zoomChanged = zoom !== searchCenter.zoom;
+  const zoomChanged = zoom !== buttonBaseCenter.zoom;
   const radius = radiusFromZoom(zoom);
-  const distance = haversineDistance(center.lat, center.lng, searchCenter.latitude, searchCenter.longitude);
+  const distance = haversineDistance(center.lat, center.lng, buttonBaseCenter.latitude, buttonBaseCenter.longitude);
   const pannedFarEnough = distance > radius * 0.3;
 
   return zoomChanged || pannedFarEnough;

--- a/tipical-frontend/src/services/businessService.ts
+++ b/tipical-frontend/src/services/businessService.ts
@@ -13,6 +13,12 @@ export const businessService = {
     return response.data;
   },
 
+  async searchByPlaceId(placeId: string, sessionToken: string): Promise<Business[]> {
+    const params = new URLSearchParams({ placeId, sessionToken });
+    const response = await apiClient.get<Business[]>(`/businesses/search?${params}`);
+    return response.data;
+  },
+
   async getById(id: string): Promise<Business> {
     const response = await apiClient.get<Business>(`/businesses/${id}`);
     return response.data;

--- a/tipical-frontend/src/stores/searchStore.ts
+++ b/tipical-frontend/src/stores/searchStore.ts
@@ -12,8 +12,16 @@ export interface SearchCenter {
 interface SearchState {
   query: string;
   searchCenter: SearchCenter;
+  buttonBaseCenter: SearchCenter;
+  placeId: string | null;
+  sessionToken: string | null;
+  fitBoundsOnResults: boolean;
   setQuery: (query: string) => void;
   setSearchCenter: (center: SearchCenter) => void;
+  setPlaceId: (placeId: string, displayText: string, sessionToken: string) => void;
+  clearFitBounds: () => void;
+  syncButtonBase: (center: SearchCenter) => void;
+  clearSearch: (center: SearchCenter) => void;
 }
 
 type SearchStoreApi = ReturnType<typeof createSearchStore>;
@@ -22,8 +30,17 @@ function createSearchStore(initialCenter: SearchCenter) {
   return createStore<SearchState>((set) => ({
     query: '',
     searchCenter: initialCenter,
-    setQuery: (query) => set({ query }),
-    setSearchCenter: (searchCenter) => set({ searchCenter }),
+    buttonBaseCenter: initialCenter,
+    placeId: null,
+    sessionToken: null,
+    fitBoundsOnResults: false,
+    setQuery: (query) => set({ query, placeId: null, sessionToken: null, fitBoundsOnResults: true }),
+    setSearchCenter: (searchCenter) => set({ searchCenter, buttonBaseCenter: searchCenter }),
+    setPlaceId: (placeId, displayText, sessionToken) =>
+      set({ placeId, query: displayText, sessionToken, fitBoundsOnResults: true }),
+    clearFitBounds: () => set({ fitBoundsOnResults: false }),
+    syncButtonBase: (buttonBaseCenter) => set({ buttonBaseCenter }),
+    clearSearch: (center) => set({ query: '', placeId: null, sessionToken: null, fitBoundsOnResults: false, searchCenter: center, buttonBaseCenter: center }),
   }));
 }
 

--- a/tipical-frontend/tsconfig.app.json
+++ b/tipical-frontend/tsconfig.app.json
@@ -5,7 +5,7 @@
     "useDefineForClassFields": true,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
-    "types": ["vite/client"],
+    "types": ["vite/client", "google.maps"],
     "skipLibCheck": true,
 
     /* Bundler mode */


### PR DESCRIPTION
Closes #130

## Summary

- **SearchBar**: wires the text input to `google.maps.places.AutocompleteSuggestion.fetchAutocompleteSuggestions`, showing a dropdown as the user types. Suggestions are biased to the live map viewport center. A UUID session token is generated at the start of each typing session and tracked alongside the JS `AutocompleteSessionToken`.
- **Place selection**: on suggestion click/Enter, calls `GET /api/v1/businesses/search?placeId=<id>&sessionToken=<token>`. The backend fetches via Place Details (New), correlates with the DB for tipping data, and returns a single result that renders as a single map pin.
- **Text search (Enter without selecting)**: runs the existing lat/lng text search, fits the map to all results with 80 px padding, then suppresses the "Search this area" button once the animation settles.
- **fitBounds**: `MapController` watches `businesses` and calls `map.fitBounds` after any search that sets `fitBoundsOnResults: true` (both place-select and text-search paths). After the animation settles, a one-shot `idle` listener calls `syncButtonBase` so the button does not reappear.
- **"Search this area" button**: shown when the map viewport has drifted significantly from `buttonBaseCenter` — the position where results were last shown. Updated by `setSearchCenter` (area search), `syncButtonBase` (post-fitBounds idle), and `clearSearch` (clear button). Decoupled from `searchCenter` so syncing the display position does not trigger a re-fetch.
- **Session token billing**: the same UUID is passed through `searchStore → useBusinessSearch → businessService → GET /search → BusinessService.PlaceDetailSearchAsync → GetPlaceAsync`, where `GetPlaceRequest.SessionToken` closes the autocomplete billing session.
- **Keyboard nav**: ArrowUp/ArrowDown move through suggestions; Escape dismisses; Enter on a highlighted item selects it.
- Added `google.maps` to `tsconfig.app.json` types array so the Places New API classes resolve correctly.

## Backend changes

| File | Change |
|------|--------|
| `IGooglePlacesService` | Add `GetPlaceAsync(placeId, sessionToken?)` |
| `GooglePlacesService` | Implement `GetPlaceAsync` using `GetPlaceRequest.SessionToken` |
| `IBusinessService` | Add `PlaceDetailSearchAsync(placeId, sessionToken?)` |
| `BusinessService` | Implement `PlaceDetailSearchAsync` — fetch place, correlate with DB, return single-element list |
| `BusinessesController.Search` | Accept optional `placeId` + `sessionToken`; dispatch to `PlaceDetailSearchAsync` when present |

## Frontend changes

| File | Change |
|------|--------|
| `searchStore.ts` | Add `placeId`, `sessionToken`, `fitBoundsOnResults`, `buttonBaseCenter`; add `setPlaceId`, `clearFitBounds`, `syncButtonBase`, and `clearSearch` actions; `setQuery` sets `fitBoundsOnResults: true`; `setSearchCenter` also updates `buttonBaseCenter` |
| `useBusinessSearch.ts` | Branch on `placeId`: keyed `['businesses', 'place', placeId]`, calls `searchByPlaceId` |
| `useSearchAreaChanged.ts` | Compares current viewport against `buttonBaseCenter` (not `searchCenter`) to avoid spurious button visibility after fitBounds |
| `businessService.ts` | Add `searchByPlaceId(placeId, sessionToken?)` |
| `SearchBar.tsx` | Autocomplete with session tokens, debounced fetch, viewport bias, keyboard nav, click-outside dismiss; `handleClear` calls `clearSearch` (no fitBounds, viewport stays fixed); `handleSubmit` snapshots current center into `searchCenter` before querying |
| `GoogleMap.tsx` | `MapController` calls `fitBounds` on results when `fitBoundsOnResults` is set; one-shot `idle` listener calls `syncButtonBase` after the animation settles |
| `App.tsx` | Pass `placeId` and `sessionToken` from store to `useBusinessSearch` |
| `tsconfig.app.json` | Add `"google.maps"` to `types` array |
