### PR TITLE
Add Sign in button for anonymous users

### DIFF
--- a/tipical-frontend/src/components/auth/UserProfile.tsx
+++ b/tipical-frontend/src/components/auth/UserProfile.tsx
@@ -1,9 +1,26 @@
 import { useState, useRef, useEffect } from 'react';
 import { useAuthStore } from '../../stores/authStore';
+import { useUIStore } from '../../stores/uiStore';
 import { useClickOutside } from '../../hooks/useClickOutside';
+import { Button } from '../common/Button';
 
-export const UserProfile = () => {
-  const { user, isAuthenticated, clearAuth } = useAuthStore();
+const SignInButton = () => {
+  const setShowAuthModal = useUIStore(s => s.setShowAuthModal);
+  return (
+    <Button
+      type="button"
+      variant="primary"
+      size="sm"
+      className="!rounded-full"
+      onClick={() => setShowAuthModal(true)}
+    >
+      Sign in
+    </Button>
+  );
+};
+
+const ProfileDropdown = () => {
+  const { user, clearAuth } = useAuthStore();
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [imgError, setImgError] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -23,9 +40,7 @@ export const UserProfile = () => {
     }
   }, [isDropdownOpen]);
 
-  if (!isAuthenticated() || !user) {
-    return null;
-  }
+  if (!user) return null;
 
   const handleLogout = () => {
     clearAuth();
@@ -145,4 +160,9 @@ export const UserProfile = () => {
       )}
     </div>
   );
+};
+
+export const UserProfile = () => {
+  const isAuthenticated = useAuthStore(s => !!s.token);
+  return isAuthenticated ? <ProfileDropdown /> : <SignInButton />;
 };


### PR DESCRIPTION
## Summary

- `UserProfile` previously returned `null` when unauthenticated, leaving anonymous users with no sign-in entry point
- Now renders a "Sign in" button in the top-right corner when the user is not authenticated
- Clicking the button calls `uiStore.setShowAuthModal(true)` to open `GoogleAuthModal`
- After successful sign-in, the button is replaced by the normal `UserProfile` component

Closes #34

## Test plan

- [x] Open the app while logged out — confirm "Sign in" button appears in the top-right corner
- [x] Click the button — confirm `GoogleAuthModal` opens
- [x] Sign in — confirm the button is replaced by the user avatar/profile component
- [x] Verify no regression for already-authenticated users (profile still renders normally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)