### PR TITLE
Return rating, review count, and photos from Places API in BusinessResponse

### DIFF
--- a/tipical-backend/src/Tipical.Core/DTOs/BusinessDTOs.cs
+++ b/tipical-backend/src/Tipical.Core/DTOs/BusinessDTOs.cs
@@ -28,10 +28,10 @@ public class BusinessResponse
     public required string GooglePlaceId { get; set; }
 
     /// <summary>Business display name.</summary>
-    public required string Name { get; set; }
+    public string Name { get; set; } = null!;
 
     /// <summary>Formatted street address.</summary>
-    public required string Address { get; set; }
+    public string Address { get; set; } = null!;
 
     /// <summary>Latitude of the business location.</summary>
     public decimal Latitude { get; set; }
@@ -40,13 +40,22 @@ public class BusinessResponse
     public decimal Longitude { get; set; }
 
     /// <summary>Google Places type tags for this business (e.g. "restaurant", "cafe").</summary>
-    public required List<string> PlaceTypes { get; set; }
+    public List<string> PlaceTypes { get; set; } = [];
 
     /// <summary>Business phone number, if available.</summary>
     public string? Phone { get; set; }
 
     /// <summary>Business website URL, if available.</summary>
     public string? Website { get; set; }
+
+    /// <summary>Google Places rating (1.0–5.0), if available.</summary>
+    public double? Rating { get; set; }
+
+    /// <summary>Total number of Google user ratings, if available.</summary>
+    public int? ReviewCount { get; set; }
+
+    /// <summary>Photo media URLs (up to 5), resolved server-side from Google Places.</summary>
+    public List<string> Photos { get; set; } = [];
 
     /// <summary>The tipping policy with the most votes, if any votes have been cast.</summary>
     public TippingPolicy? WinningPolicy { get; set; }

--- a/tipical-backend/src/Tipical.Core/Services/IGooglePlacesService.cs
+++ b/tipical-backend/src/Tipical.Core/Services/IGooglePlacesService.cs
@@ -9,4 +9,5 @@ public interface IGooglePlacesService
     Task<AutocompletePlacesResponse> AutocompleteAsync(string input, double latitude, double longitude, int radius);
     Task<Place> GetPlaceAsync(string placeId, string sessionToken);
     Task<IReadOnlyList<Place>> BulkFetchAsync(IEnumerable<string> placeIds);
+    Task<string?> GetPhotoMediaUriAsync(string photoName, int maxWidthPx = 400);
 }

--- a/tipical-backend/src/Tipical.Infrastructure/FieldMaskBuilder.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/FieldMaskBuilder.cs
@@ -80,6 +80,14 @@ public sealed class FieldMaskNode<TRoot, TCurrent>
         _hasUncommittedPath = hasUncommittedPath;
     }
 
+    public FieldMaskNode<TRoot, TElement> ThenInclude<TElement>(Expression<Func<TCurrent, RepeatedField<TElement>>> selector)
+    {
+        CommitIfNeeded();
+        var memberPath = FieldMaskRoot<TRoot>.GetMemberName(selector.Body);
+        var path = string.IsNullOrEmpty(_currentPath) ? memberPath : $"{_currentPath}.{memberPath}";
+        return new FieldMaskNode<TRoot, TElement>(_root, path);
+    }
+
     public FieldMaskNode<TRoot, TNext> ThenInclude<TNext>(Expression<Func<TCurrent, TNext>> selector)
     {
         if (selector.Body is NewExpression newExpr)

--- a/tipical-backend/src/Tipical.Infrastructure/Services/BusinessService.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Services/BusinessService.cs
@@ -12,6 +12,7 @@ public class BusinessService(
     IGooglePlacesService googlePlacesService) : IBusinessService
 {
     private const int MaxResults = 20;
+    private const int MaxPhotos = 5;
 
     public async Task<List<BusinessResponse>> PlaceDetailSearchAsync(string placeId, string sessionToken)
     {
@@ -20,9 +21,10 @@ public class BusinessService(
         catch (RpcException) { return []; }
 
         var businessByPlaceId = await businessRepository.GetByGooglePlaceIdsAsync([placeId]);
+        var photos = await FetchPhotoUrisAsync(place);
         var response = businessByPlaceId.TryGetValue(placeId, out var business)
-            ? MapDbBusinessToResponse(business, place)
-            : MapPlaceToResponse(place);
+            ? MapDbBusinessToResponse(business, place, photos)
+            : MapPlaceToResponse(place, photos);
         return [response];
     }
 
@@ -44,11 +46,13 @@ public class BusinessService(
             places.Select(p => p.Id));
 
         // Step 3: Build responses in Places relevance order
-        return places.Select(p =>
-            businessByPlaceId.TryGetValue(p.Id, out var business)
-                ? MapDbBusinessToResponse(business, p)
-                : MapPlaceToResponse(p))
-            .ToList();
+        return [.. await Task.WhenAll(places.Select(async p =>
+        {
+            var photos = await FetchPhotoUrisAsync(p);
+            return businessByPlaceId.TryGetValue(p.Id, out var business)
+                ? MapDbBusinessToResponse(business, p, photos)
+                : MapPlaceToResponse(p, photos);
+        }))];
     }
 
     private async Task<List<BusinessResponse>> NearbySearchAsync(BusinessSearchRequest request)
@@ -91,52 +95,62 @@ public class BusinessService(
 
         // Step 4: Build responses for DB businesses (already sorted by policy from the query).
         //         Enrich with Google Places display data when available.
-        var dbResponses = dbBusinesses
+        var dbResponsesTask = Task.WhenAll(dbBusinesses
             .Where(b => placesById.ContainsKey(b.GooglePlaceId))
-            .Select(b => MapDbBusinessToResponse(b, placesById[b.GooglePlaceId]));
+            .Select(async b =>
+            {
+                var place = placesById[b.GooglePlaceId];
+                return MapDbBusinessToResponse(b, place, await FetchPhotoUrisAsync(place));
+            }));
 
-        // Step 5: Append placeholder responses for Google Places backfill
-        var backfillResponses = backfillPlaces.Select(MapPlaceToResponse);
+        // Step 5: Append placeholder responses for Google Places backfill — runs in parallel with step 4
+        var backfillResponsesTask = Task.WhenAll(backfillPlaces
+            .Select(async p => MapPlaceToResponse(p, await FetchPhotoUrisAsync(p))));
 
-        return [.. dbResponses, .. backfillResponses];
+        return [.. await dbResponsesTask, .. await backfillResponsesTask];
     }
 
-    private static BusinessResponse MapDbBusinessToResponse(Business business, Place place)
+    private async Task<List<string>> FetchPhotoUrisAsync(Place place)
     {
+        var uris = await Task.WhenAll(
+            place.Photos.Take(MaxPhotos).Select(p => googlePlacesService.GetPhotoMediaUriAsync(p.Name)));
+        return [.. uris.OfType<string>()];
+    }
+
+    private static BusinessResponse ApplyPlaceFields(BusinessResponse response, Place place, List<string> photos)
+    {
+        response.Name = place.DisplayName.Text;
+        response.Address = place.FormattedAddress;
+        response.Latitude = (decimal)place.Location.Latitude;
+        response.Longitude = (decimal)place.Location.Longitude;
+        response.PlaceTypes = [.. place.Types_];
+        response.Phone = !string.IsNullOrWhiteSpace(place.InternationalPhoneNumber) ? place.InternationalPhoneNumber : null;
+        response.Website = !string.IsNullOrWhiteSpace(place.WebsiteUri) ? place.WebsiteUri : null;
+        response.Rating = place.HasUserRatingCount && place.UserRatingCount > 0 ? place.Rating : null;
+        response.ReviewCount = place.HasUserRatingCount ? place.UserRatingCount : null;
+        response.Photos = photos;
+        return response;
+    }
+
+    private static BusinessResponse MapDbBusinessToResponse(Business business, Place place, List<string> photos)
+    {
+        // TippingVotes is always non-empty: Business rows are only created inside the
+        // SubmitVoteAsync transaction, which atomically upserts a vote in the same commit.
         var winner = business.TippingVotes
             .GroupBy(v => v.TippingPolicy)
             .Select(g => (Policy: g.Key, Count: g.Count()))
             .OrderByDescending(x => x.Count)
             .First();
 
-        return new BusinessResponse
+        return ApplyPlaceFields(new BusinessResponse
         {
             Id = business.Id,
             GooglePlaceId = business.GooglePlaceId,
-            Name = place.DisplayName.Text,
-            Address = place.FormattedAddress,
-            Latitude = (decimal)place.Location.Latitude,
-            Longitude = (decimal)place.Location.Longitude,
-            PlaceTypes = [.. place.Types_],
-            Phone = !string.IsNullOrWhiteSpace(place.InternationalPhoneNumber) ? place.InternationalPhoneNumber : null,
-            Website = !string.IsNullOrWhiteSpace(place.WebsiteUri) ? place.WebsiteUri : null,
             WinningPolicy = winner.Policy,
             WinningPolicyVoteCount = winner.Count
-        };
+        }, place, photos);
     }
 
-    private static BusinessResponse MapPlaceToResponse(Place place) =>
-        new()
-        {
-            GooglePlaceId = place.Id,
-            Name = place.DisplayName.Text,
-            Address = place.FormattedAddress,
-            Latitude = (decimal)place.Location.Latitude,
-            Longitude = (decimal)place.Location.Longitude,
-            PlaceTypes = [.. place.Types_],
-            Phone = !string.IsNullOrWhiteSpace(place.InternationalPhoneNumber) ? place.InternationalPhoneNumber : null,
-            Website = !string.IsNullOrWhiteSpace(place.WebsiteUri) ? place.WebsiteUri : null,
-            WinningPolicy = null,
-            WinningPolicyVoteCount = null
-        };
+    private static BusinessResponse MapPlaceToResponse(Place place, List<string> photos) =>
+        ApplyPlaceFields(new BusinessResponse { GooglePlaceId = place.Id }, place, photos);
 }

--- a/tipical-backend/src/Tipical.Infrastructure/Services/GooglePlacesService.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Services/GooglePlacesService.cs
@@ -10,19 +10,27 @@ public class GooglePlacesService : IGooglePlacesService
 {
     private static readonly CallSettings GetPlaceSettings =
         FieldMask.For<Place>()
-            .Include(p => new { p.Id, p.DisplayName, p.FormattedAddress, p.Types_, p.InternationalPhoneNumber, p.WebsiteUri, p.Location })
+            .Include(p => new { p.Id, p.DisplayName, p.FormattedAddress, p.Types_, p.InternationalPhoneNumber, p.WebsiteUri, p.Location, p.Rating, p.UserRatingCount })
+            .Include(p => p.Photos)
+            .ThenInclude(photo => photo.Name)
             .ToCallSettings();
 
     private static readonly CallSettings NearbySearchSettings =
         FieldMask.For<SearchNearbyResponse>()
             .Include(r => r.Places)
-            .ThenInclude(p => new { p.Id, p.DisplayName, p.FormattedAddress, p.Types_, p.InternationalPhoneNumber, p.WebsiteUri, p.Location })
+            .ThenInclude(p => new { p.Id, p.DisplayName, p.FormattedAddress, p.Types_, p.InternationalPhoneNumber, p.WebsiteUri, p.Location, p.Rating, p.UserRatingCount })
+            .Include(r => r.Places)
+            .ThenInclude(p => p.Photos)
+            .ThenInclude(photo => photo.Name)
             .ToCallSettings();
 
     private static readonly CallSettings TextSearchSettings =
         FieldMask.For<SearchTextResponse>()
             .Include(r => r.Places)
-            .ThenInclude(p => new { p.Id, p.DisplayName, p.FormattedAddress, p.Types_, p.InternationalPhoneNumber, p.WebsiteUri, p.Location })
+            .ThenInclude(p => new { p.Id, p.DisplayName, p.FormattedAddress, p.Types_, p.InternationalPhoneNumber, p.WebsiteUri, p.Location, p.Rating, p.UserRatingCount })
+            .Include(r => r.Places)
+            .ThenInclude(p => p.Photos)
+            .ThenInclude(photo => photo.Name)
             .ToCallSettings();
 
     private readonly PlacesClient _client;
@@ -84,6 +92,21 @@ public class GooglePlacesService : IGooglePlacesService
             catch { return null; }
         });
         return (await Task.WhenAll(tasks)).Where(p => p != null).Select(p => p!).ToList();
+    }
+
+    public async Task<string?> GetPhotoMediaUriAsync(string photoName, int maxWidthPx = 400)
+    {
+        try
+        {
+            var media = await _client.GetPhotoMediaAsync(new GetPhotoMediaRequest
+            {
+                Name = $"{photoName}/media",
+                MaxWidthPx = maxWidthPx,
+                SkipHttpRedirect = true
+            });
+            return string.IsNullOrWhiteSpace(media.PhotoUri) ? null : media.PhotoUri;
+        }
+        catch { return null; }
     }
 
     public async Task<AutocompletePlacesResponse> AutocompleteAsync(string input, double latitude, double longitude, int radius)

--- a/tipical-backend/tests/Tipical.Infrastructure.Tests/FieldMaskBuilderTests.cs
+++ b/tipical-backend/tests/Tipical.Infrastructure.Tests/FieldMaskBuilderTests.cs
@@ -21,6 +21,7 @@ public class FieldMaskBuilderTests
         public string Name { get; set; } = "";
         public string Types_ { get; set; } = "";
         public TestSub Sub { get; set; } = new();
+        public RepeatedField<TestSub> SubItems { get; set; } = [];
     }
 
     private sealed class TestSub
@@ -169,6 +170,18 @@ public class FieldMaskBuilderTests
             .Build();
 
         await Assert.That(mask).IsEqualTo("id,name,types");
+    }
+
+    [Test]
+    public async Task NestedRepeatedField_NavigatesThroughElementType()
+    {
+        var mask = FieldMask.For<TestResponse>()
+            .Include(r => r.Items)
+            .ThenInclude(i => i.SubItems)
+            .ThenInclude(s => new { s.Text, s.LanguageCode })
+            .Build();
+
+        await Assert.That(mask).IsEqualTo("items.subItems.text,items.subItems.languageCode");
     }
 
     [Test]


### PR DESCRIPTION
## Summary

- Adds `Rating` (double?), `ReviewCount` (int?), and `Photos` (up to 5 URLs) to `BusinessResponse`
- Extends the `GetPlace`, `SearchNearby`, and `SearchText` field masks to request `rating`, `userRatingCount`, and `photos.name` from the Places API; adds a `ThenInclude<TElement>(RepeatedField<TElement>)` overload to `FieldMaskBuilder` to support chaining through nested repeated fields
- Adds `GetPhotoMediaUriAsync` to `IGooglePlacesService` / `GooglePlacesService` — calls `PlacesClient.GetPhotoMediaAsync` with `SkipHttpRedirect = true` to obtain short-lived signed CDN URLs server-side without ever exposing the API key to clients
- Adds `ApplyPlaceFields` static helper to `BusinessService` that sets all 10 Place-derived fields on a pre-constructed `BusinessResponse`; both `MapDbBusinessToResponse` and `MapPlaceToResponse` delegate to it, eliminating the duplication
- Photo fetches within each search path use `Task.WhenAll`; in `NearbySearchAsync` the DB and backfill batches are fetched in parallel

Closes #145

## Test plan

- [ ] Search nearby and confirm response includes `rating`, `reviewCount`, and `photos` for results that have them
- [ ] Confirm `photos` is an empty array (not null) for places with no photos
- [ ] Confirm `rating` and `reviewCount` are `null` (not 0) for places with no ratings
- [ ] Confirm photo URLs are reachable and return images
- [ ] Confirm single-place lookup via `placeId` also returns the new fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)
