### PR TITLE
Split BusinessResponse into pin and detail DTOs, add lazy detail endpoint

### DIFF
--- a/tipical-backend/src/Tipical.Api/Controllers/BusinessesController.cs
+++ b/tipical-backend/src/Tipical.Api/Controllers/BusinessesController.cs
@@ -16,8 +16,8 @@ public class BusinessesController(IBusinessService businessService, ILogger<Busi
     /// <param name="longitude">Center longitude of the search area (used when placeId is absent).</param>
     /// <param name="radius">Search radius in meters (used when placeId is absent).</param>
     [HttpGet("search")]
-    [ProducesResponseType(typeof(List<BusinessResponse>), StatusCodes.Status200OK)]
-    public async Task<ActionResult<List<BusinessResponse>>> Search(
+    [ProducesResponseType(typeof(List<BusinessPinResponse>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<List<BusinessPinResponse>>> Search(
         [FromQuery] string? placeId,
         [FromQuery] string? sessionToken,
         [FromQuery] string? query,
@@ -43,5 +43,18 @@ public class BusinessesController(IBusinessService businessService, ILogger<Busi
 
         var results = await businessService.SearchBusinessesAsync(request);
         return Ok(results);
+    }
+
+    /// <summary>Fetch rich detail for a single business by Google Place ID.</summary>
+    /// <param name="googlePlaceId">Google Place ID of the business.</param>
+    [HttpGet("{googlePlaceId}/details")]
+    [ProducesResponseType(typeof(BusinessDetailResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<BusinessDetailResponse>> GetDetails(string googlePlaceId)
+    {
+        if (string.IsNullOrWhiteSpace(googlePlaceId))
+            return BadRequest("googlePlaceId is required.");
+        var result = await businessService.GetBusinessDetailAsync(googlePlaceId);
+        return result is null ? NotFound() : Ok(result);
     }
 }

--- a/tipical-backend/src/Tipical.Core/DTOs/BusinessDTOs.cs
+++ b/tipical-backend/src/Tipical.Core/DTOs/BusinessDTOs.cs
@@ -18,8 +18,8 @@ public class BusinessSearchRequest
     public required int Radius { get; set; }
 }
 
-/// <summary>Business details with crowd-sourced tipping policy summary.</summary>
-public class BusinessResponse
+/// <summary>Lean business data needed to render a map pin.</summary>
+public class BusinessPinResponse
 {
     /// <summary>Internal Tipical business ID.</summary>
     public Guid Id { get; set; }
@@ -42,6 +42,19 @@ public class BusinessResponse
     /// <summary>Google Places type tags for this business (e.g. "restaurant", "cafe").</summary>
     public List<string> PlaceTypes { get; set; } = [];
 
+    /// <summary>The tipping policy with the most votes, if any votes have been cast.</summary>
+    public TippingPolicy? WinningPolicy { get; set; }
+
+    /// <summary>Number of votes for the winning policy.</summary>
+    public int? WinningPolicyVoteCount { get; set; }
+}
+
+/// <summary>Rich business detail fetched lazily when a pin is opened.</summary>
+public class BusinessDetailResponse
+{
+    /// <summary>Formatted street address.</summary>
+    public string Address { get; set; } = null!;
+
     /// <summary>Business phone number, if available.</summary>
     public string? Phone { get; set; }
 
@@ -56,10 +69,4 @@ public class BusinessResponse
 
     /// <summary>Photo media URLs (up to 5), resolved server-side from Google Places.</summary>
     public List<string> Photos { get; set; } = [];
-
-    /// <summary>The tipping policy with the most votes, if any votes have been cast.</summary>
-    public TippingPolicy? WinningPolicy { get; set; }
-
-    /// <summary>Number of votes for the winning policy.</summary>
-    public int? WinningPolicyVoteCount { get; set; }
 }

--- a/tipical-backend/src/Tipical.Core/Services/IBusinessService.cs
+++ b/tipical-backend/src/Tipical.Core/Services/IBusinessService.cs
@@ -4,6 +4,7 @@ namespace Tipical.Core.Services;
 
 public interface IBusinessService
 {
-    Task<List<BusinessResponse>> SearchBusinessesAsync(BusinessSearchRequest request);
-    Task<List<BusinessResponse>> PlaceDetailSearchAsync(string placeId, string sessionToken);
+    Task<List<BusinessPinResponse>> SearchBusinessesAsync(BusinessSearchRequest request);
+    Task<List<BusinessPinResponse>> PlaceDetailSearchAsync(string placeId, string sessionToken);
+    Task<BusinessDetailResponse?> GetBusinessDetailAsync(string googlePlaceId);
 }

--- a/tipical-backend/src/Tipical.Core/Services/IGooglePlacesService.cs
+++ b/tipical-backend/src/Tipical.Core/Services/IGooglePlacesService.cs
@@ -8,6 +8,7 @@ public interface IGooglePlacesService
     Task<SearchNearbyResponse> SearchNearbyAsync(double latitude, double longitude, int radius, int maxResultCount = 20);
     Task<AutocompletePlacesResponse> AutocompleteAsync(string input, double latitude, double longitude, int radius);
     Task<Place> GetPlaceAsync(string placeId, string sessionToken);
+    Task<Place> GetPlaceDetailsAsync(string placeId);
     Task<IReadOnlyList<Place>> BulkFetchAsync(IEnumerable<string> placeIds);
     Task<string?> GetPhotoMediaUriAsync(string photoName, int maxWidthPx = 400);
 }

--- a/tipical-backend/src/Tipical.Infrastructure/Services/BusinessService.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Services/BusinessService.cs
@@ -14,26 +14,43 @@ public class BusinessService(
     private const int MaxResults = 20;
     private const int MaxPhotos = 5;
 
-    public async Task<List<BusinessResponse>> PlaceDetailSearchAsync(string placeId, string sessionToken)
+    public async Task<List<BusinessPinResponse>> PlaceDetailSearchAsync(string placeId, string sessionToken)
     {
         Place place;
         try { place = await googlePlacesService.GetPlaceAsync(placeId, sessionToken); }
         catch (RpcException) { return []; }
 
         var businessByPlaceId = await businessRepository.GetByGooglePlaceIdsAsync([placeId]);
-        var photos = await FetchPhotoUrisAsync(place);
         var response = businessByPlaceId.TryGetValue(placeId, out var business)
-            ? MapDbBusinessToResponse(business, place, photos)
-            : MapPlaceToResponse(place, photos);
+            ? MapDbBusinessToResponse(business, place)
+            : MapPlaceToResponse(place);
         return [response];
     }
 
-    public Task<List<BusinessResponse>> SearchBusinessesAsync(BusinessSearchRequest request) =>
+    public Task<List<BusinessPinResponse>> SearchBusinessesAsync(BusinessSearchRequest request) =>
         string.IsNullOrWhiteSpace(request.Query)
             ? NearbySearchAsync(request)
             : TextSearchAsync(request);
 
-    private async Task<List<BusinessResponse>> TextSearchAsync(BusinessSearchRequest request)
+    public async Task<BusinessDetailResponse?> GetBusinessDetailAsync(string googlePlaceId)
+    {
+        Place place;
+        try { place = await googlePlacesService.GetPlaceDetailsAsync(googlePlaceId); }
+        catch { return null; }
+
+        var photos = await FetchPhotoUrisAsync(place);
+        return new BusinessDetailResponse
+        {
+            Address = place.FormattedAddress,
+            Phone = !string.IsNullOrWhiteSpace(place.InternationalPhoneNumber) ? place.InternationalPhoneNumber : null,
+            Website = !string.IsNullOrWhiteSpace(place.WebsiteUri) ? place.WebsiteUri : null,
+            Rating = place.HasUserRatingCount && place.UserRatingCount > 0 ? place.Rating : null,
+            ReviewCount = place.HasUserRatingCount ? place.UserRatingCount : null,
+            Photos = photos,
+        };
+    }
+
+    private async Task<List<BusinessPinResponse>> TextSearchAsync(BusinessSearchRequest request)
     {
         // Step 1: Places API text search is the authoritative source and ordering
         var placesResult = await googlePlacesService.SearchAsync(
@@ -46,16 +63,13 @@ public class BusinessService(
             places.Select(p => p.Id));
 
         // Step 3: Build responses in Places relevance order
-        return [.. await Task.WhenAll(places.Select(async p =>
-        {
-            var photos = await FetchPhotoUrisAsync(p);
-            return businessByPlaceId.TryGetValue(p.Id, out var business)
-                ? MapDbBusinessToResponse(business, p, photos)
-                : MapPlaceToResponse(p, photos);
-        }))];
+        return [.. places.Select(p =>
+            businessByPlaceId.TryGetValue(p.Id, out var business)
+                ? MapDbBusinessToResponse(business, p)
+                : MapPlaceToResponse(p))];
     }
 
-    private async Task<List<BusinessResponse>> NearbySearchAsync(BusinessSearchRequest request)
+    private async Task<List<BusinessPinResponse>> NearbySearchAsync(BusinessSearchRequest request)
     {
         // Step 1: Query DB for known businesses near the requested location, sorted by policy priority
         var dbBusinesses = await businessRepository.SearchNearbyAsync(
@@ -95,19 +109,14 @@ public class BusinessService(
 
         // Step 4: Build responses for DB businesses (already sorted by policy from the query).
         //         Enrich with Google Places display data when available.
-        var dbResponsesTask = Task.WhenAll(dbBusinesses
+        var dbResponses = dbBusinesses
             .Where(b => placesById.ContainsKey(b.GooglePlaceId))
-            .Select(async b =>
-            {
-                var place = placesById[b.GooglePlaceId];
-                return MapDbBusinessToResponse(b, place, await FetchPhotoUrisAsync(place));
-            }));
+            .Select(b => MapDbBusinessToResponse(b, placesById[b.GooglePlaceId]));
 
-        // Step 5: Append placeholder responses for Google Places backfill — runs in parallel with step 4
-        var backfillResponsesTask = Task.WhenAll(backfillPlaces
-            .Select(async p => MapPlaceToResponse(p, await FetchPhotoUrisAsync(p))));
+        // Step 5: Append placeholder responses for Google Places backfill
+        var backfillResponses = backfillPlaces.Select(MapPlaceToResponse);
 
-        return [.. await dbResponsesTask, .. await backfillResponsesTask];
+        return [.. dbResponses, .. backfillResponses];
     }
 
     private async Task<List<string>> FetchPhotoUrisAsync(Place place)
@@ -117,22 +126,17 @@ public class BusinessService(
         return [.. uris.OfType<string>()];
     }
 
-    private static BusinessResponse ApplyPlaceFields(BusinessResponse response, Place place, List<string> photos)
+    private static BusinessPinResponse ApplyPlaceFields(BusinessPinResponse response, Place place)
     {
         response.Name = place.DisplayName.Text;
         response.Address = place.FormattedAddress;
         response.Latitude = (decimal)place.Location.Latitude;
         response.Longitude = (decimal)place.Location.Longitude;
         response.PlaceTypes = [.. place.Types_];
-        response.Phone = !string.IsNullOrWhiteSpace(place.InternationalPhoneNumber) ? place.InternationalPhoneNumber : null;
-        response.Website = !string.IsNullOrWhiteSpace(place.WebsiteUri) ? place.WebsiteUri : null;
-        response.Rating = place.HasUserRatingCount && place.UserRatingCount > 0 ? place.Rating : null;
-        response.ReviewCount = place.HasUserRatingCount ? place.UserRatingCount : null;
-        response.Photos = photos;
         return response;
     }
 
-    private static BusinessResponse MapDbBusinessToResponse(Business business, Place place, List<string> photos)
+    private static BusinessPinResponse MapDbBusinessToResponse(Business business, Place place)
     {
         // TippingVotes is always non-empty: Business rows are only created inside the
         // SubmitVoteAsync transaction, which atomically upserts a vote in the same commit.
@@ -142,15 +146,15 @@ public class BusinessService(
             .OrderByDescending(x => x.Count)
             .First();
 
-        return ApplyPlaceFields(new BusinessResponse
+        return ApplyPlaceFields(new BusinessPinResponse
         {
             Id = business.Id,
             GooglePlaceId = business.GooglePlaceId,
             WinningPolicy = winner.Policy,
             WinningPolicyVoteCount = winner.Count
-        }, place, photos);
+        }, place);
     }
 
-    private static BusinessResponse MapPlaceToResponse(Place place, List<string> photos) =>
-        ApplyPlaceFields(new BusinessResponse { GooglePlaceId = place.Id }, place, photos);
+    private static BusinessPinResponse MapPlaceToResponse(Place place) =>
+        ApplyPlaceFields(new BusinessPinResponse { GooglePlaceId = place.Id }, place);
 }

--- a/tipical-backend/src/Tipical.Infrastructure/Services/GooglePlacesService.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Services/GooglePlacesService.cs
@@ -10,26 +10,25 @@ public class GooglePlacesService : IGooglePlacesService
 {
     private static readonly CallSettings GetPlaceSettings =
         FieldMask.For<Place>()
-            .Include(p => new { p.Id, p.DisplayName, p.FormattedAddress, p.Types_, p.InternationalPhoneNumber, p.WebsiteUri, p.Location, p.Rating, p.UserRatingCount })
-            .Include(p => p.Photos)
-            .ThenInclude(photo => photo.Name)
+            .Include(p => new { p.Id, p.DisplayName, p.FormattedAddress, p.Location, p.Types_ })
             .ToCallSettings();
 
     private static readonly CallSettings NearbySearchSettings =
         FieldMask.For<SearchNearbyResponse>()
             .Include(r => r.Places)
-            .ThenInclude(p => new { p.Id, p.DisplayName, p.FormattedAddress, p.Types_, p.InternationalPhoneNumber, p.WebsiteUri, p.Location, p.Rating, p.UserRatingCount })
-            .Include(r => r.Places)
-            .ThenInclude(p => p.Photos)
-            .ThenInclude(photo => photo.Name)
+            .ThenInclude(p => new { p.Id, p.DisplayName, p.FormattedAddress, p.Location, p.Types_ })
             .ToCallSettings();
 
     private static readonly CallSettings TextSearchSettings =
         FieldMask.For<SearchTextResponse>()
             .Include(r => r.Places)
-            .ThenInclude(p => new { p.Id, p.DisplayName, p.FormattedAddress, p.Types_, p.InternationalPhoneNumber, p.WebsiteUri, p.Location, p.Rating, p.UserRatingCount })
-            .Include(r => r.Places)
-            .ThenInclude(p => p.Photos)
+            .ThenInclude(p => new { p.Id, p.DisplayName, p.FormattedAddress, p.Location, p.Types_ })
+            .ToCallSettings();
+
+    private static readonly CallSettings DetailPlaceSettings =
+        FieldMask.For<Place>()
+            .Include(p => new { p.FormattedAddress, p.InternationalPhoneNumber, p.WebsiteUri, p.Rating, p.UserRatingCount })
+            .Include(p => p.Photos)
             .ThenInclude(photo => photo.Name)
             .ToCallSettings();
 
@@ -82,6 +81,13 @@ public class GooglePlacesService : IGooglePlacesService
         return await _client.GetPlaceAsync(
             new GetPlaceRequest { Name = $"places/{placeId}", SessionToken = sessionToken },
             GetPlaceSettings);
+    }
+
+    public async Task<Place> GetPlaceDetailsAsync(string placeId)
+    {
+        return await _client.GetPlaceAsync(
+            new GetPlaceRequest { Name = $"places/{placeId}" },
+            DetailPlaceSettings);
     }
 
     public async Task<IReadOnlyList<Place>> BulkFetchAsync(IEnumerable<string> placeIds)

--- a/tipical-frontend/src/App.tsx
+++ b/tipical-frontend/src/App.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import { APIProvider, useApiLoadingStatus } from '@vis.gl/react-google-maps';
 import { useInitialLocation } from './hooks/useInitialLocation';
 import { useBusinessSearch } from './hooks/useBusinessSearch';
@@ -8,6 +9,8 @@ import { SearchBar } from './components/search';
 import { BusinessDetailPanel } from './components/business';
 import { UserProfile, GoogleAuthModal } from './components/auth';
 import { Loading } from './components/common';
+import { useUIStore } from './stores/uiStore';
+import type { Business } from './types';
 
 function accuracyToZoom(accuracy: number): number {
   return Math.max(10, Math.min(17, Math.round(16 - Math.log2(accuracy / 50))));
@@ -16,6 +19,17 @@ function accuracyToZoom(accuracy: number): number {
 interface AppLayoutProps {
   initialCenter: { lat: number; lng: number };
   initialZoom: number;
+}
+
+function BusinessDetailPanelWrapper() {
+  const selectedBusiness = useUIStore(s => s.selectedBusiness);
+  const [displayBusiness, setDisplayBusiness] = useState<Business | null>(selectedBusiness);
+  useEffect(() => {
+    if (selectedBusiness) setDisplayBusiness(selectedBusiness);
+  }, [selectedBusiness]);
+
+  if (!displayBusiness) return null;
+  return <BusinessDetailPanel business={displayBusiness} />;
 }
 
 function AppLayout({ initialCenter, initialZoom }: AppLayoutProps) {
@@ -41,7 +55,7 @@ function AppLayout({ initialCenter, initialZoom }: AppLayoutProps) {
         userProfileSlot={<UserProfile />}
       />
 
-      <BusinessDetailPanel />
+      <BusinessDetailPanelWrapper />
       <GoogleAuthModal />
     </div>
   );

--- a/tipical-frontend/src/components/business/BusinessDetailPanel.tsx
+++ b/tipical-frontend/src/components/business/BusinessDetailPanel.tsx
@@ -1,85 +1,94 @@
-import { useState, useEffect } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { Sidebar } from '../common/Sidebar';
 import { TippingPolicyDisplay } from '../tipping/TippingPolicyDisplay';
 import { TippingPolicySelector } from '../tipping/TippingPolicySelector';
 import { useUIStore } from '../../stores/uiStore';
+import { useBusinessDetail } from '../../hooks';
+import type { Business } from '../../types';
 
-export function BusinessDetailPanel() {
-  const { selectedBusiness, showBusinessPanel, closeBusinessPanel } = useUIStore(
+interface BusinessDetailPanelProps {
+  business: Business;
+}
+
+export function BusinessDetailPanel({ business }: BusinessDetailPanelProps) {
+  const { showBusinessPanel, closeBusinessPanel } = useUIStore(
     useShallow(s => ({
-      selectedBusiness: s.selectedBusiness,
       showBusinessPanel: s.showBusinessPanel,
       closeBusinessPanel: s.closeBusinessPanel,
     }))
   );
 
-  // Preserve last business so content stays visible during the close animation
-  const [displayBusiness, setDisplayBusiness] = useState(selectedBusiness);
-  useEffect(() => {
-    if (selectedBusiness) setDisplayBusiness(selectedBusiness);
-  }, [selectedBusiness]);
+  const { data: detail, isLoading: detailLoading } = useBusinessDetail(business.googlePlaceId);
 
   return (
     <Sidebar
       isOpen={showBusinessPanel}
       onClose={closeBusinessPanel}
-      title={displayBusiness?.name}
+      title={business.name}
       width="md"
     >
-      {displayBusiness && (
-        <div className="space-y-6">
-          {/* Business info */}
-          <div className="space-y-2">
-            <p className="text-sm text-gray-600">{displayBusiness.address}</p>
-            {displayBusiness.phone && (
-              <p className="text-sm text-gray-600">{displayBusiness.phone}</p>
-            )}
-            {displayBusiness.website && (
-              <a
-                href={displayBusiness.website}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-sm text-blue-600 hover:underline break-all"
-              >
-                {displayBusiness.website}
-              </a>
-            )}
-            {displayBusiness.placeTypes && displayBusiness.placeTypes.length > 0 && (
-              <div className="flex flex-wrap gap-1 pt-1">
-                {displayBusiness.placeTypes.map(type => (
-                  <span
-                    key={type}
-                    className="inline-block px-2 py-0.5 bg-gray-100 text-gray-600 text-xs rounded-full"
-                  >
-                    {type.replace(/_/g, ' ')}
-                  </span>
-                ))}
-              </div>
-            )}
-          </div>
-
-          <hr className="border-gray-200" />
-
-          {/* Tipping policy display */}
-          <div className="space-y-2">
-            <h3 className="text-sm font-semibold text-gray-900 uppercase tracking-wide">
-              Tipping Policy
-            </h3>
-            <TippingPolicyDisplay business={displayBusiness} />
-          </div>
-
-          <hr className="border-gray-200" />
-
-          {/* Vote */}
-          <div className="space-y-2">
-            <h3 className="text-sm font-semibold text-gray-900 uppercase tracking-wide">
-              Cast Your Vote
-            </h3>
-            <TippingPolicySelector business={displayBusiness} />
-          </div>
+      <div className="space-y-6">
+        {/* Business info */}
+        <div className="space-y-2">
+          {detailLoading ? (
+            <div className="space-y-2">
+              <div className="animate-pulse h-4 bg-gray-100 rounded w-3/4" />
+              <div className="animate-pulse h-4 bg-gray-100 rounded w-1/2" />
+            </div>
+          ) : (
+            <>
+              <p className="text-sm text-gray-600">
+                {business.address ?? detail?.address}
+              </p>
+              {detail?.phone && (
+                <p className="text-sm text-gray-600">{detail.phone}</p>
+              )}
+              {detail?.website && (
+                <a
+                  href={detail.website}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-sm text-blue-600 hover:underline break-all"
+                >
+                  {detail.website}
+                </a>
+              )}
+            </>
+          )}
+          {business.placeTypes && business.placeTypes.length > 0 && (
+            <div className="flex flex-wrap gap-1 pt-1">
+              {business.placeTypes.map(type => (
+                <span
+                  key={type}
+                  className="inline-block px-2 py-0.5 bg-gray-100 text-gray-600 text-xs rounded-full"
+                >
+                  {type.replace(/_/g, ' ')}
+                </span>
+              ))}
+            </div>
+          )}
         </div>
-      )}
+
+        <hr className="border-gray-200" />
+
+        {/* Tipping policy display */}
+        <div className="space-y-2">
+          <h3 className="text-sm font-semibold text-gray-900 uppercase tracking-wide">
+            Tipping Policy
+          </h3>
+          <TippingPolicyDisplay business={business} />
+        </div>
+
+        <hr className="border-gray-200" />
+
+        {/* Vote */}
+        <div className="space-y-2">
+          <h3 className="text-sm font-semibold text-gray-900 uppercase tracking-wide">
+            Cast Your Vote
+          </h3>
+          <TippingPolicySelector business={business} />
+        </div>
+      </div>
     </Sidebar>
   );
 }

--- a/tipical-frontend/src/components/map/BusinessInfoWindow.tsx
+++ b/tipical-frontend/src/components/map/BusinessInfoWindow.tsx
@@ -1,4 +1,5 @@
 import { useUIStore } from '../../stores/uiStore';
+import { useBusinessDetail } from '../../hooks';
 import type { Business, TippingPolicy as TippingPolicyType } from '../../types';
 import { TippingPolicy } from '../../types';
 
@@ -21,6 +22,7 @@ interface BusinessInfoWindowProps {
 
 export function BusinessInfoWindow({ business, onClose }: BusinessInfoWindowProps) {
   const openBusinessPanel = useUIStore(s => s.openBusinessPanel);
+  const { data: detail, isLoading: detailLoading } = useBusinessDetail(business.googlePlaceId);
 
   const handleViewDetails = () => {
     onClose();
@@ -43,6 +45,16 @@ export function BusinessInfoWindow({ business, onClose }: BusinessInfoWindowProp
           No data yet
         </span>
       )}
+      {detailLoading ? (
+        <div className="animate-pulse h-3 bg-gray-100 rounded w-16 mb-2" />
+      ) : detail?.rating != null ? (
+        <p className="text-xs text-gray-500 mb-2">
+          ★ {detail.rating.toFixed(1)}
+          {detail.reviewCount != null && (
+            <span className="ml-1">({detail.reviewCount.toLocaleString()})</span>
+          )}
+        </p>
+      ) : null}
       <button
         aria-label={`View details for ${business.name}`}
         onClick={handleViewDetails}

--- a/tipical-frontend/src/hooks/index.ts
+++ b/tipical-frontend/src/hooks/index.ts
@@ -5,3 +5,4 @@ export { useDebounce } from './useDebounce';
 export { useBusinessSearch, useBusinessById } from './useBusinessSearch';
 export { useTippingData } from './useTippingData';
 export { useSearchAreaChanged } from './useSearchAreaChanged';
+export { useBusinessDetail } from './useBusinessDetail';

--- a/tipical-frontend/src/hooks/useBusinessDetail.ts
+++ b/tipical-frontend/src/hooks/useBusinessDetail.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { businessService } from '../services/businessService';
+import type { BusinessDetail } from '../types';
+
+export function useBusinessDetail(googlePlaceId: string) {
+  return useQuery<BusinessDetail>({
+    queryKey: ['businessDetail', googlePlaceId],
+    queryFn: () => businessService.getDetails(googlePlaceId),
+
+  });
+}

--- a/tipical-frontend/src/services/businessService.ts
+++ b/tipical-frontend/src/services/businessService.ts
@@ -1,5 +1,5 @@
 import { apiClient } from './api';
-import type { Business } from '../types';
+import type { Business, BusinessDetail } from '../types';
 
 export const businessService = {
   async search(query: string | undefined, latitude: number, longitude: number, radius: number): Promise<Business[]> {
@@ -21,6 +21,11 @@ export const businessService = {
 
   async getById(id: string): Promise<Business> {
     const response = await apiClient.get<Business>(`/businesses/${id}`);
+    return response.data;
+  },
+
+  async getDetails(googlePlaceId: string): Promise<BusinessDetail> {
+    const response = await apiClient.get<BusinessDetail>(`/businesses/${googlePlaceId}/details`);
     return response.data;
   },
 };

--- a/tipical-frontend/src/types/index.ts
+++ b/tipical-frontend/src/types/index.ts
@@ -10,14 +10,21 @@ export interface Business {
   id: string;
   googlePlaceId: string;
   name: string;
-  address: string;
+  address?: string;
   latitude: number;
   longitude: number;
   placeTypes?: string[];
-  phone?: string;
-  website?: string;
   winningPolicy?: TippingPolicy;
   winningPolicyVoteCount?: number;
+}
+
+export interface BusinessDetail {
+  address: string;
+  phone?: string;
+  website?: string;
+  rating?: number;
+  reviewCount?: number;
+  photos: string[];
 }
 
 export interface TippingVote {


### PR DESCRIPTION
Closes #148

## Summary

- **Backend:** Splits `BusinessResponse` into `BusinessPinResponse` (lean, search endpoint) and `BusinessDetailResponse` (rich, new `GET /api/v1/businesses/{googlePlaceId}/details` endpoint). Slims all Places API field masks (`GetPlaceSettings`, `NearbySearchSettings`, `TextSearchSettings`) to Pro-tier fields only (`id`, `displayName`, `location`, `types`, `formattedAddress`), removing all Enterprise-tier fields. Adds `DetailPlaceSettings` with Enterprise-tier fields (`rating`, `userRatingCount`, `internationalPhoneNumber`, `websiteUri`) plus Pro-tier `photos.name`, used exclusively by the new detail endpoint via `GetPlaceDetailsAsync`.

- **Frontend:** Makes `address` optional on the `Business` TypeScript type and adds a `BusinessDetail` type that always includes `address` as a fallback. Adds `businessService.getDetails()`, a `useBusinessDetail` hook (React Query-cached by `googlePlaceId`), and wires both `BusinessDetailPanel` and `BusinessInfoWindow` to call it — the panel shows a skeleton while loading and uses `Business.address ?? BusinessDetail.address`, the info window shows rating once resolved.

## Billing impact

Before this change, every search RPC (including `BulkFetchAsync` fanning out up to 20 calls) included Enterprise-tier fields, billing each call at the Enterprise rate. After this change, search RPCs request only Pro-tier fields (address is kept for backward compatibility — see rollout note below). Enterprise-tier calls only happen when a user opens the detail panel for a specific pin.

## Rollout

`address` is included in both the search response and the detail response during this transition. The frontend prefers the search-response value and falls back to the detail response, so it will work correctly after a future backend release (#150) drops `address` from the search response to reach Basic-tier billing.

## Test plan

- [ ] Map pins load and display correctly (name, policy badge) after the search field mask change
- [ ] Opening a pin's info window shows a loading skeleton, then rating once the detail fetch resolves
- [ ] Opening the detail panel shows a skeleton, then populates address/phone/website once resolved
- [ ] Re-opening the same pin skips the network call (React Query cache hit)
- [ ] `GET /api/v1/businesses/{googlePlaceId}/details` returns `404` for an unknown place ID
- [ ] Autocomplete → pin selection still works (session token still closes correctly on `GetPlaceAsync`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
