### PR TITLE
Slim search field masks to Basic tier, drop address from pin response

### DIFF
--- a/tipical-backend/src/Tipical.Core/DTOs/BusinessDTOs.cs
+++ b/tipical-backend/src/Tipical.Core/DTOs/BusinessDTOs.cs
@@ -30,9 +30,6 @@ public class BusinessPinResponse
     /// <summary>Business display name.</summary>
     public string Name { get; set; } = null!;
 
-    /// <summary>Formatted street address.</summary>
-    public string Address { get; set; } = null!;
-
     /// <summary>Latitude of the business location.</summary>
     public decimal Latitude { get; set; }
 
@@ -53,7 +50,7 @@ public class BusinessPinResponse
 public class BusinessDetailResponse
 {
     /// <summary>Formatted street address.</summary>
-    public string Address { get; set; } = null!;
+    public string? Address { get; set; }
 
     /// <summary>Business phone number, if available.</summary>
     public string? Phone { get; set; }

--- a/tipical-backend/src/Tipical.Infrastructure/Services/BusinessService.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Services/BusinessService.cs
@@ -36,12 +36,12 @@ public class BusinessService(
     {
         Place place;
         try { place = await googlePlacesService.GetPlaceDetailsAsync(googlePlaceId); }
-        catch { return null; }
+        catch (RpcException) { return null; }
 
         var photos = await FetchPhotoUrisAsync(place);
         return new BusinessDetailResponse
         {
-            Address = place.FormattedAddress,
+            Address = !string.IsNullOrWhiteSpace(place.FormattedAddress) ? place.FormattedAddress : null,
             Phone = !string.IsNullOrWhiteSpace(place.InternationalPhoneNumber) ? place.InternationalPhoneNumber : null,
             Website = !string.IsNullOrWhiteSpace(place.WebsiteUri) ? place.WebsiteUri : null,
             Rating = place.HasUserRatingCount && place.UserRatingCount > 0 ? place.Rating : null,
@@ -129,7 +129,6 @@ public class BusinessService(
     private static BusinessPinResponse ApplyPlaceFields(BusinessPinResponse response, Place place)
     {
         response.Name = place.DisplayName.Text;
-        response.Address = place.FormattedAddress;
         response.Latitude = (decimal)place.Location.Latitude;
         response.Longitude = (decimal)place.Location.Longitude;
         response.PlaceTypes = [.. place.Types_];

--- a/tipical-backend/src/Tipical.Infrastructure/Services/GooglePlacesService.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Services/GooglePlacesService.cs
@@ -10,19 +10,19 @@ public class GooglePlacesService : IGooglePlacesService
 {
     private static readonly CallSettings GetPlaceSettings =
         FieldMask.For<Place>()
-            .Include(p => new { p.Id, p.DisplayName, p.FormattedAddress, p.Location, p.Types_ })
+            .Include(p => new { p.Id, p.DisplayName, p.Location, p.Types_ })
             .ToCallSettings();
 
     private static readonly CallSettings NearbySearchSettings =
         FieldMask.For<SearchNearbyResponse>()
             .Include(r => r.Places)
-            .ThenInclude(p => new { p.Id, p.DisplayName, p.FormattedAddress, p.Location, p.Types_ })
+            .ThenInclude(p => new { p.Id, p.DisplayName, p.Location, p.Types_ })
             .ToCallSettings();
 
     private static readonly CallSettings TextSearchSettings =
         FieldMask.For<SearchTextResponse>()
             .Include(r => r.Places)
-            .ThenInclude(p => new { p.Id, p.DisplayName, p.FormattedAddress, p.Location, p.Types_ })
+            .ThenInclude(p => new { p.Id, p.DisplayName, p.Location, p.Types_ })
             .ToCallSettings();
 
     private static readonly CallSettings DetailPlaceSettings =

--- a/tipical-frontend/src/components/business/BusinessDetailPanel.tsx
+++ b/tipical-frontend/src/components/business/BusinessDetailPanel.tsx
@@ -37,9 +37,9 @@ export function BusinessDetailPanel({ business }: BusinessDetailPanelProps) {
             </div>
           ) : (
             <>
-              <p className="text-sm text-gray-600">
-                {business.address ?? detail?.address}
-              </p>
+              {detail?.address && (
+                <p className="text-sm text-gray-600">{detail.address}</p>
+              )}
               {detail?.phone && (
                 <p className="text-sm text-gray-600">{detail.phone}</p>
               )}

--- a/tipical-frontend/src/types/index.ts
+++ b/tipical-frontend/src/types/index.ts
@@ -10,7 +10,6 @@ export interface Business {
   id: string;
   googlePlaceId: string;
   name: string;
-  address?: string;
   latitude: number;
   longitude: number;
   placeTypes?: string[];
@@ -19,7 +18,7 @@ export interface Business {
 }
 
 export interface BusinessDetail {
-  address: string;
+  address?: string;
   phone?: string;
   website?: string;
   rating?: number;


### PR DESCRIPTION
## Summary

- Removes `formattedAddress` from `GetPlaceSettings`, `NearbySearchSettings`, and `TextSearchSettings` — search RPCs now request only `id`, `displayName`, `location`, `types` (Basic tier billing)
- Drops `Address` from `BusinessPinResponse` and its `ApplyPlaceFields` mapping; address is exclusively returned by the detail endpoint
- Removes `address?` from the `Business` frontend type and replaces the `business.address ?? detail?.address` fallback in `BusinessDetailPanel` with `detail?.address` directly

## Test plan

- [ ] Open the map and confirm businesses render as pins without errors
- [ ] Click a pin and confirm the address loads (after the detail fetch) in the panel
- [ ] Confirm no TypeScript errors (`npx tsc --noEmit`)
- [ ] Confirm backend builds cleanly (`dotnet build`)

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)