### PR TITLE
Overhaul BusinessInfoWindow with carousel, review data, vote count, and auth-aware CTA

### DIFF
--- a/tipical-frontend/src/components/map/BusinessInfoWindow.tsx
+++ b/tipical-frontend/src/components/map/BusinessInfoWindow.tsx
@@ -1,19 +1,10 @@
+import { useState } from 'react';
 import { useUIStore } from '../../stores/uiStore';
+import { useAuthStore } from '../../stores/authStore';
 import { useBusinessDetail } from '../../hooks';
-import type { Business, TippingPolicy as TippingPolicyType } from '../../types';
-import { TippingPolicy } from '../../types';
-
-const POLICY_LABELS: Record<TippingPolicyType, string> = {
-  [TippingPolicy.NoTips]: 'No Tips',
-  [TippingPolicy.TipsExcludeTax]: 'Tips on Subtotal',
-  [TippingPolicy.TipsIncludeTax]: 'Tips on Total',
-};
-
-const POLICY_COLORS: Record<TippingPolicyType, string> = {
-  [TippingPolicy.NoTips]: 'bg-green-100 text-green-800',
-  [TippingPolicy.TipsExcludeTax]: 'bg-yellow-100 text-yellow-800',
-  [TippingPolicy.TipsIncludeTax]: 'bg-red-100 text-red-800',
-};
+import { Button } from '../common/Button';
+import type { Business } from '../../types';
+import { POLICY_LABELS, POLICY_BADGE_STYLES } from '../../utils/policy';
 
 interface BusinessInfoWindowProps {
   business: Business;
@@ -22,46 +13,132 @@ interface BusinessInfoWindowProps {
 
 export function BusinessInfoWindow({ business, onClose }: BusinessInfoWindowProps) {
   const openBusinessPanel = useUIStore(s => s.openBusinessPanel);
-  const { data: detail, isLoading: detailLoading } = useBusinessDetail(business.googlePlaceId);
+  const setShowAuthModal = useUIStore(s => s.setShowAuthModal);
+  const isAuthenticated = useAuthStore(s => !!s.token);
+  const { data: detail, isLoading: detailLoading, isError: detailError } = useBusinessDetail(business.googlePlaceId);
+  const [photoIndex, setPhotoIndex] = useState(0);
 
-  const handleViewDetails = () => {
+  const photos = detail?.photos ?? [];
+
+  const handleCTA = () => {
     onClose();
-    openBusinessPanel(business);
+    if (isAuthenticated) {
+      openBusinessPanel(business);
+    } else {
+      setShowAuthModal(true);
+    }
+  };
+
+  const prevPhoto = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setPhotoIndex(i => (i - 1 + photos.length) % photos.length);
+  };
+
+  const nextPhoto = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setPhotoIndex(i => (i + 1) % photos.length);
+  };
+
+  const renderPhotoArea = () => {
+    if (detailLoading) {
+      return <div className="animate-pulse h-28 bg-gray-200 rounded-t" />;
+    }
+    if (detailError) {
+      return (
+        <div className="h-28 rounded-t bg-gray-100 flex items-center justify-center">
+          <span className="text-gray-400 text-xs">Photos unavailable</span>
+        </div>
+      );
+    }
+    if (photos.length > 0) {
+      return (
+        <div className="relative h-28 overflow-hidden rounded-t">
+          <img
+            src={photos[photoIndex]}
+            alt={business.name}
+            className="w-full h-full object-cover"
+          />
+          {photos.length > 1 && (
+            <>
+              <button
+                aria-label="Previous photo"
+                onClick={prevPhoto}
+                className="absolute left-1 top-1/2 -translate-y-1/2 bg-black/40 text-white rounded-full w-5 h-5 text-xs flex items-center justify-center leading-none"
+              >
+                ‹
+              </button>
+              <button
+                aria-label="Next photo"
+                onClick={nextPhoto}
+                className="absolute right-1 top-1/2 -translate-y-1/2 bg-black/40 text-white rounded-full w-5 h-5 text-xs flex items-center justify-center leading-none"
+              >
+                ›
+              </button>
+              <span className="absolute bottom-1 right-1 bg-black/40 text-white text-xs rounded px-1">
+                {photoIndex + 1}/{photos.length}
+              </span>
+            </>
+          )}
+        </div>
+      );
+    }
+    return (
+      <div className="h-28 rounded-t bg-gray-100 flex items-center justify-center">
+        <span className="text-gray-400 text-xs">No photos</span>
+      </div>
+    );
   };
 
   return (
-    <div className="min-w-[180px] max-w-[240px] p-1">
-      <p className="font-semibold text-gray-900 text-sm leading-tight mb-1">
-        {business.name}
-      </p>
-      {business.winningPolicy !== undefined ? (
-        <span
-          className={`inline-block text-xs font-medium px-2 py-0.5 rounded-full mb-2 ${POLICY_COLORS[business.winningPolicy]}`}
-        >
-          {POLICY_LABELS[business.winningPolicy]}
-        </span>
-      ) : (
-        <span className="inline-block text-xs font-medium px-2 py-0.5 rounded-full mb-2 bg-gray-100 text-gray-600">
-          No data yet
-        </span>
-      )}
-      {detailLoading ? (
-        <div className="animate-pulse h-3 bg-gray-100 rounded w-16 mb-2" />
-      ) : detail?.rating != null ? (
-        <p className="text-xs text-gray-500 mb-2">
-          ★ {detail.rating.toFixed(1)}
-          {detail.reviewCount != null && (
-            <span className="ml-1">({detail.reviewCount.toLocaleString()})</span>
-          )}
+    <div className="min-w-[200px] max-w-[260px]">
+      {renderPhotoArea()}
+
+      <div className="p-2">
+        <p className="font-semibold text-gray-900 text-sm leading-tight mb-1">
+          {business.name}
         </p>
-      ) : null}
-      <button
-        aria-label={`View details for ${business.name}`}
-        onClick={handleViewDetails}
-        className="block w-full text-center text-xs font-medium text-blue-600 hover:text-blue-800 hover:underline"
-      >
-        View Details →
-      </button>
+
+        {detailLoading ? (
+          <div className="animate-pulse h-3 bg-gray-100 rounded w-20 mb-2" />
+        ) : detail?.rating != null ? (
+          <p className="text-xs text-gray-500 mb-2">
+            ★ {detail.rating.toFixed(1)}
+            {detail.reviewCount != null && (
+              <span className="ml-1">· {detail.reviewCount.toLocaleString()} reviews</span>
+            )}
+          </p>
+        ) : null}
+
+        {business.winningPolicy !== undefined ? (
+          <span
+            className={`inline-block text-xs font-medium px-2 py-0.5 rounded-full ${POLICY_BADGE_STYLES[business.winningPolicy]}`}
+          >
+            {POLICY_LABELS[business.winningPolicy]}
+          </span>
+        ) : (
+          <span className="inline-block text-xs font-medium px-2 py-0.5 rounded-full bg-gray-100 text-gray-600">
+            No data yet
+          </span>
+        )}
+
+        {business.winningPolicyVoteCount != null && business.winningPolicyVoteCount > 0 && (
+          <p className="text-xs text-gray-400 mt-0.5 mb-1">
+            Based on {business.winningPolicyVoteCount}{' '}
+            {business.winningPolicyVoteCount === 1 ? 'vote' : 'votes'}
+          </p>
+        )}
+
+        <Button
+          variant={isAuthenticated ? 'primary' : 'secondary'}
+          size="sm"
+          fullWidth
+          onClick={handleCTA}
+          aria-label={isAuthenticated ? `Vote for ${business.name}` : `Sign in to vote for ${business.name}`}
+          className="mt-2"
+        >
+          {isAuthenticated ? 'Vote' : 'Sign in to vote'}
+        </Button>
+      </div>
     </div>
   );
 }

--- a/tipical-frontend/src/components/tipping/TippingPolicyDisplay.tsx
+++ b/tipical-frontend/src/components/tipping/TippingPolicyDisplay.tsx
@@ -1,18 +1,6 @@
 import { useTippingData } from '../../hooks';
-import type { Business, TippingPolicy as TippingPolicyType } from '../../types';
-import { TippingPolicy } from '../../types';
-
-const POLICY_LABELS: Record<TippingPolicyType, string> = {
-  [TippingPolicy.NoTips]: 'No Tips',
-  [TippingPolicy.TipsExcludeTax]: 'Tips on Subtotal',
-  [TippingPolicy.TipsIncludeTax]: 'Tips on Total',
-};
-
-const POLICY_BADGE_STYLES: Record<TippingPolicyType, string> = {
-  [TippingPolicy.NoTips]: 'bg-green-100 text-green-800',
-  [TippingPolicy.TipsExcludeTax]: 'bg-yellow-100 text-yellow-800',
-  [TippingPolicy.TipsIncludeTax]: 'bg-red-100 text-red-800',
-};
+import type { Business } from '../../types';
+import { POLICY_LABELS, POLICY_BADGE_STYLES } from '../../utils/policy';
 
 interface TippingPolicyDisplayProps {
   business: Business;

--- a/tipical-frontend/src/utils/policy.ts
+++ b/tipical-frontend/src/utils/policy.ts
@@ -1,0 +1,14 @@
+import { TippingPolicy } from '../types';
+import type { TippingPolicy as TippingPolicyType } from '../types';
+
+export const POLICY_LABELS: Record<TippingPolicyType, string> = {
+  [TippingPolicy.NoTips]: 'No Tips',
+  [TippingPolicy.TipsExcludeTax]: 'Tips on Subtotal',
+  [TippingPolicy.TipsIncludeTax]: 'Tips on Total',
+};
+
+export const POLICY_BADGE_STYLES: Record<TippingPolicyType, string> = {
+  [TippingPolicy.NoTips]: 'bg-green-100 text-green-800',
+  [TippingPolicy.TipsExcludeTax]: 'bg-yellow-100 text-yellow-800',
+  [TippingPolicy.TipsIncludeTax]: 'bg-red-100 text-red-800',
+};


### PR DESCRIPTION
Closes #146

## Summary

- **Photo carousel** — shows photos from `BusinessDetail` at the top of the popup with prev/next arrow navigation and a photo counter badge; falls back to a "No photos" placeholder when none are available
- **Review data** — displays `★ rating · N reviews` below the business name, with a skeleton loader while detail fetches
- **Vote count** — shows "Based on N votes" beneath the winning-policy badge when `winningPolicyVoteCount > 0`; hidden otherwise
- **Auth-aware CTA** — replaces "View Details →" with a solid **Vote** button (opens `BusinessPanel`) for authenticated users and an outlined **Sign in to vote** button (opens `GoogleAuthModal`) for anonymous users

## Test plan

- [ ] Open an info window on a business with photos — carousel renders, arrows navigate, counter updates
- [ ] Open an info window on a business without photos — "No photos" placeholder shown
- [ ] Verify rating and review count display correctly
- [ ] Verify "Based on N votes" shows only when votes exist
- [ ] While signed out: click "Sign in to vote" → auth modal opens
- [ ] While signed in: click "Vote" → business panel opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)