### PR TITLE
Remove dead code left over from issue #144 feature work

### DIFF
--- a/tipical-frontend/src/hooks/index.ts
+++ b/tipical-frontend/src/hooks/index.ts
@@ -2,7 +2,7 @@ export { useClickOutside } from './useClickOutside';
 export { useGeolocation } from './useGeolocation';
 export { useInitialLocation } from './useInitialLocation';
 export { useDebounce } from './useDebounce';
-export { useBusinessSearch, useBusinessById } from './useBusinessSearch';
+export { useBusinessSearch } from './useBusinessSearch';
 export { useTippingData } from './useTippingData';
 export { useSearchAreaChanged } from './useSearchAreaChanged';
 export { useBusinessDetail } from './useBusinessDetail';

--- a/tipical-frontend/src/hooks/useBusinessSearch.ts
+++ b/tipical-frontend/src/hooks/useBusinessSearch.ts
@@ -29,10 +29,3 @@ export function useBusinessSearch({ query, searchCenter, placeId, sessionToken }
   });
 }
 
-export function useBusinessById(id: string | null) {
-  return useQuery<Business>({
-    queryKey: ['businesses', id],
-    queryFn: () => businessService.getById(id!),
-    enabled: Boolean(id),
-  });
-}

--- a/tipical-frontend/src/services/businessService.ts
+++ b/tipical-frontend/src/services/businessService.ts
@@ -19,11 +19,6 @@ export const businessService = {
     return response.data;
   },
 
-  async getById(id: string): Promise<Business> {
-    const response = await apiClient.get<Business>(`/businesses/${id}`);
-    return response.data;
-  },
-
   async getDetails(googlePlaceId: string): Promise<BusinessDetail> {
     const response = await apiClient.get<BusinessDetail>(`/businesses/${googlePlaceId}/details`);
     return response.data;

--- a/tipical-frontend/src/types/index.ts
+++ b/tipical-frontend/src/types/index.ts
@@ -7,7 +7,6 @@ export const TippingPolicy = {
 export type TippingPolicy = typeof TippingPolicy[keyof typeof TippingPolicy];
 
 export interface Business {
-  id: string;
   googlePlaceId: string;
   name: string;
   latitude: number;


### PR DESCRIPTION
## Summary

- Drop `BusinessPinResponse.Id` / `Business.id` — `googlePlaceId` is the identifier used everywhere; the internal DB ID was never read on the frontend
- Remove `useBusinessById` hook and `businessService.getById` — the app uses `useBusinessDetail` for lazy detail fetching; this hook had no callers
- Remove `IBusinessRepository.GetByIdAsync` and its implementation — no callers; all lookups go through `GetByGooglePlaceIdAsync`
- Remove `UserInfoResponse` DTO, `GET /api/v1/auth/me` endpoint, and `GetUserInfoFromClaims` — the frontend sources user profile data exclusively from the `AuthResponse` returned at login; the `/me` endpoint was never called

## Test plan

- [ ] Map pins load and open `BusinessInfoWindow` as before
- [ ] Voting flow works end-to-end (submitting and updating a vote)
- [ ] Sign in / sign out flow works
- [ ] Backend builds with no errors (`dotnet build`)
- [ ] Frontend type-checks with no errors (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
