### PR TITLE
Remove dead backend code left over from issue #144 feature work

### DIFF
--- a/tipical-backend/src/Tipical.Api/Controllers/AuthController.cs
+++ b/tipical-backend/src/Tipical.Api/Controllers/AuthController.cs
@@ -1,4 +1,3 @@
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
@@ -50,14 +49,4 @@ public class AuthController(
         }
     }
 
-    /// <summary>Return the authenticated user's profile.</summary>
-    [HttpGet("me")]
-    [Authorize]
-    [ProducesResponseType(typeof(UserInfoResponse), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-    public ActionResult<UserInfoResponse> GetCurrentUser()
-    {
-        var userInfo = googleAuthService.GetUserInfoFromClaims(User);
-        return Ok(userInfo);
-    }
 }

--- a/tipical-backend/src/Tipical.Core/DTOs/AuthDTOs.cs
+++ b/tipical-backend/src/Tipical.Core/DTOs/AuthDTOs.cs
@@ -25,19 +25,3 @@ public class AuthResponse
     /// <summary>URL of the authenticated user's profile picture, if available.</summary>
     public string? Picture { get; set; }
 }
-
-/// <summary>Profile information for the currently authenticated user.</summary>
-public class UserInfoResponse
-{
-    /// <summary>Unique identifier for the user.</summary>
-    public string UserId { get; set; } = string.Empty;
-
-    /// <summary>User's email address.</summary>
-    public string Email { get; set; } = string.Empty;
-
-    /// <summary>User's display name.</summary>
-    public string Name { get; set; } = string.Empty;
-
-    /// <summary>URL of the user's profile picture, if available.</summary>
-    public string? Picture { get; set; }
-}

--- a/tipical-backend/src/Tipical.Core/DTOs/BusinessDTOs.cs
+++ b/tipical-backend/src/Tipical.Core/DTOs/BusinessDTOs.cs
@@ -21,9 +21,6 @@ public class BusinessSearchRequest
 /// <summary>Lean business data needed to render a map pin.</summary>
 public class BusinessPinResponse
 {
-    /// <summary>Internal Tipical business ID.</summary>
-    public Guid Id { get; set; }
-
     /// <summary>Google Place ID for this business.</summary>
     public required string GooglePlaceId { get; set; }
 

--- a/tipical-backend/src/Tipical.Core/Repositories/IBusinessRepository.cs
+++ b/tipical-backend/src/Tipical.Core/Repositories/IBusinessRepository.cs
@@ -5,7 +5,6 @@ namespace Tipical.Core.Repositories;
 
 public interface IBusinessRepository
 {
-    Task<Business?> GetByIdAsync(Guid id);
     Task<Business?> GetByGooglePlaceIdAsync(string googlePlaceId);
     Task<Dictionary<string, Business>> GetByGooglePlaceIdsAsync(IEnumerable<string> googlePlaceIds);
     Task<Business> GetOrCreateAsync(string googlePlaceId, string name, Point location);

--- a/tipical-backend/src/Tipical.Core/Services/IGoogleAuthService.cs
+++ b/tipical-backend/src/Tipical.Core/Services/IGoogleAuthService.cs
@@ -1,4 +1,3 @@
-using System.Security.Claims;
 using Tipical.Core.DTOs;
 
 namespace Tipical.Core.Services;
@@ -6,5 +5,4 @@ namespace Tipical.Core.Services;
 public interface IGoogleAuthService
 {
     Task<AuthResponse> VerifyGoogleTokenAsync(string idToken);
-    UserInfoResponse GetUserInfoFromClaims(ClaimsPrincipal user);
 }

--- a/tipical-backend/src/Tipical.Infrastructure/Repositories/BusinessRepository.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Repositories/BusinessRepository.cs
@@ -9,13 +9,6 @@ namespace Tipical.Infrastructure.Repositories;
 
 public class BusinessRepository(ApplicationDbContext context) : IBusinessRepository
 {
-    public async Task<Business?> GetByIdAsync(Guid id)
-    {
-        return await context.Businesses
-            .Include(b => b.TippingVotes)
-            .SingleOrDefaultAsync(b => b.Id == id);
-    }
-
     public async Task<Business?> GetByGooglePlaceIdAsync(string googlePlaceId)
     {
         return await context.Businesses

--- a/tipical-backend/src/Tipical.Infrastructure/Services/BusinessService.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Services/BusinessService.cs
@@ -147,7 +147,6 @@ public class BusinessService(
 
         return ApplyPlaceFields(new BusinessPinResponse
         {
-            Id = business.Id,
             GooglePlaceId = business.GooglePlaceId,
             WinningPolicy = winner.Policy,
             WinningPolicyVoteCount = winner.Count

--- a/tipical-backend/src/Tipical.Infrastructure/Services/GoogleAuthService.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Services/GoogleAuthService.cs
@@ -70,14 +70,4 @@ public class GoogleAuthService(IConfiguration configuration) : IGoogleAuthServic
         return new JwtSecurityTokenHandler().WriteToken(token);
     }
 
-    public UserInfoResponse GetUserInfoFromClaims(ClaimsPrincipal user)
-    {
-        return new UserInfoResponse
-        {
-            UserId = user.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? user.FindFirst(JwtRegisteredClaimNames.Sub)?.Value ?? "",
-            Email = user.FindFirst(ClaimTypes.Email)?.Value ?? user.FindFirst(JwtRegisteredClaimNames.Email)?.Value ?? "",
-            Name = user.FindFirst(ClaimTypes.Name)?.Value ?? user.FindFirst(JwtRegisteredClaimNames.Name)?.Value ?? "",
-            Picture = user.FindFirst("picture")?.Value
-        };
-    }
 }


### PR DESCRIPTION
## Summary

- Drop `BusinessPinResponse.Id` — `googlePlaceId` is the identifier used everywhere; the internal DB ID was never read by the frontend
- Remove `IBusinessRepository.GetByIdAsync` and its implementation — no callers; all lookups go through `GetByGooglePlaceIdAsync`
- Remove `UserInfoResponse` DTO, `GET /api/v1/auth/me` endpoint, and `GetUserInfoFromClaims` — the frontend sources user data exclusively from the `AuthResponse` returned at login; the `/me` endpoint was never called

## Test plan

- [ ] Map pins load and open `BusinessInfoWindow` as before
- [ ] Voting flow works end-to-end (submitting and updating a vote)
- [ ] Sign in / sign out flow works
- [ ] Backend builds with no errors (`dotnet build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
