### PR TITLE
Fix BusinessInfoWindow layout shift when main photo loads

### DIFF
--- a/tipical-frontend/src/components/map/BusinessInfoWindow.tsx
+++ b/tipical-frontend/src/components/map/BusinessInfoWindow.tsx
@@ -41,7 +41,7 @@ export function BusinessInfoWindow({ business, onClose }: BusinessInfoWindowProp
 
   const renderPhotoArea = () => {
     if (detailLoading) {
-      return <div className="animate-pulse h-28 bg-gray-200 rounded-t" />;
+      return <div className="animate-pulse w-full h-28 bg-gray-200 rounded-t" />;
     }
     if (detailError) {
       return (
@@ -90,7 +90,7 @@ export function BusinessInfoWindow({ business, onClose }: BusinessInfoWindowProp
   };
 
   return (
-    <div className="min-w-[200px] max-w-[260px]">
+    <div className="w-[260px]">
       {renderPhotoArea()}
 
       <div className="p-2">


### PR DESCRIPTION
Fixes #155

## What changed

- **Outer container**: changed from `min-w-[200px] max-w-[260px]` to a fixed `w-[260px]`. This pins the InfoWindow to a stable width from the moment it renders, so the Google Maps bubble never needs to reflow when photo data arrives.
- **Loading placeholder**: added `w-full` so the gray skeleton fills the same 260 px that the loaded photo will occupy, keeping the visual footprint identical before and after load.

## Why this works

Previously the InfoWindow was sized by its text content while `detailLoading` was true (no photo yet). When the first `<img>` finished loading, Google Maps measured the new content and snapped the bubble wider. With a fixed container width both the placeholder and the image occupy exactly the same space, so no reflow occurs.
