### PR TITLE
Redesign business pins: teardrop shape, correct anchor, and active highlight

### DIFF
--- a/tipical-frontend/src/components/map/BusinessMarker.tsx
+++ b/tipical-frontend/src/components/map/BusinessMarker.tsx
@@ -1,15 +1,23 @@
 import { useCallback, useMemo } from 'react';
 import { AdvancedMarker, InfoWindow } from '@vis.gl/react-google-maps';
-import type { Business, TippingPolicy as TippingPolicyType } from '../../types';
-import { TippingPolicy } from '../../types';
+import type { Business } from '../../types';
 import { BusinessInfoWindow } from './BusinessInfoWindow';
+import { POLICY_HEX_COLORS } from '../../utils/policy';
 
-const POLICY_COLORS: Record<TippingPolicyType | 'unknown', string> = {
-  [TippingPolicy.NoTips]: '#22c55e',
-  [TippingPolicy.TipsExcludeTax]: '#eab308',
-  [TippingPolicy.TipsIncludeTax]: '#ef4444',
-  unknown: '#9ca3af',
-};
+const PIN_WIDTH = 22;
+const PIN_HEIGHT = 32;
+const PIN_CX = PIN_WIDTH / 2; // horizontal center and circle head radius
+
+// vis.gl InfoWindow pixelOffset is a [x, y] tuple (it constructs google.maps.Size internally).
+// Negative y moves the stem tip upward. PIN_HEIGHT brings the tip to the SVG top edge;
+// the extra 2px accounts for the active stroke (2.5px) extending ~1.25px above that edge.
+const INFO_WINDOW_OFFSET: [number, number] = [0, -(PIN_HEIGHT + 2)];
+
+// Teardrop path derived from PIN_WIDTH/PIN_HEIGHT: circle head of radius PIN_CX at top,
+// tip at bottom-center. AdvancedMarker anchors at center-bottom so the tip aligns with lat/lng.
+const PIN_KO = PIN_CX * (1 - 0.5523);                         // Bezier quarter-circle offset
+const PIN_TAPER_Y = PIN_CX + (PIN_HEIGHT - PIN_CX) * 0.19;    // taper control-point y
+const PIN_PATH = `M${PIN_CX} 0 C${PIN_KO} 0 0 ${PIN_KO} 0 ${PIN_CX} C0 ${PIN_TAPER_Y} ${PIN_CX} ${PIN_HEIGHT} ${PIN_CX} ${PIN_HEIGHT} C${PIN_CX} ${PIN_HEIGHT} ${PIN_WIDTH} ${PIN_TAPER_Y} ${PIN_WIDTH} ${PIN_CX} C${PIN_WIDTH} ${PIN_KO} ${PIN_WIDTH - PIN_KO} 0 ${PIN_CX} 0 Z`;
 
 interface BusinessMarkerProps {
   business: Business;
@@ -24,12 +32,15 @@ export function BusinessMarker({ business, isActive, onMarkerClick, onInfoWindow
     [business.latitude, business.longitude]
   );
 
-  const color = POLICY_COLORS[business.winningPolicy ?? 'unknown'];
+  const color = POLICY_HEX_COLORS[business.winningPolicy ?? 'unknown'];
 
   const handleClick = useCallback(
     () => onMarkerClick(business.googlePlaceId),
     [onMarkerClick, business.googlePlaceId]
   );
+
+  // Each pin needs a unique filter id to avoid SVG filter collisions between markers.
+  const filterId = `pin-shadow-${business.googlePlaceId}`;
 
   return (
     <>
@@ -37,12 +48,38 @@ export function BusinessMarker({ business, isActive, onMarkerClick, onInfoWindow
         position={position}
         title={business.name}
         onClick={handleClick}
+        zIndex={isActive ? 10 : 0}
       >
-        <div style={{ width: 28, height: 28, borderRadius: '50%', background: color, border: '2.5px solid white', boxShadow: '0 1px 4px rgba(0,0,0,0.3)', cursor: 'pointer' }} />
+        <svg
+          width={PIN_WIDTH}
+          height={PIN_HEIGHT}
+          viewBox={`0 0 ${PIN_WIDTH} ${PIN_HEIGHT}`}
+          style={{ cursor: 'pointer', display: 'block', overflow: 'visible' }}
+        >
+          <defs>
+            <filter id={filterId} x="-50%" y="-50%" width="200%" height="200%">
+              <feDropShadow
+                dx="0"
+                dy="1"
+                stdDeviation={isActive ? 3 : 1.5}
+                floodColor={isActive ? color : '#000000'}
+                floodOpacity={isActive ? 0.5 : 0.3}
+              />
+            </filter>
+          </defs>
+          <path
+            d={PIN_PATH}
+            fill={color}
+            stroke="white"
+            strokeWidth={isActive ? 2.5 : 1.5}
+            filter={`url(#${filterId})`}
+          />
+          <circle cx={PIN_CX} cy={PIN_CX} r={4} fill="white" opacity={0.4} />
+        </svg>
       </AdvancedMarker>
 
       {isActive && (
-        <InfoWindow position={position} onCloseClick={onInfoWindowClose}>
+        <InfoWindow position={position} pixelOffset={INFO_WINDOW_OFFSET} onCloseClick={onInfoWindowClose}>
           <BusinessInfoWindow business={business} onClose={onInfoWindowClose} />
         </InfoWindow>
       )}

--- a/tipical-frontend/src/utils/policy.ts
+++ b/tipical-frontend/src/utils/policy.ts
@@ -12,3 +12,10 @@ export const POLICY_BADGE_STYLES: Record<TippingPolicyType, string> = {
   [TippingPolicy.TipsExcludeTax]: 'bg-yellow-100 text-yellow-800',
   [TippingPolicy.TipsIncludeTax]: 'bg-red-100 text-red-800',
 };
+
+export const POLICY_HEX_COLORS: Record<TippingPolicyType | 'unknown', string> = {
+  [TippingPolicy.NoTips]: '#22c55e',
+  [TippingPolicy.TipsExcludeTax]: '#eab308',
+  [TippingPolicy.TipsIncludeTax]: '#ef4444',
+  unknown: '#9ca3af',
+};


### PR DESCRIPTION
Closes #157

## Summary

- Replaces the 28px circle `<div>` in `BusinessMarker` with an SVG teardrop pin (22×38px). The tip of the pin is at the bottom-center of the SVG element, which aligns with `AdvancedMarker`'s default center-bottom anchor — so the tip naturally sits at the business's lat/lng with no extra offset needed.
- When a pin's info window is open (`isActive`), the pin gets a thicker white stroke and a colored drop shadow (using the policy color) to make it visually distinct. Its `zIndex` is also raised so it renders on top of neighboring pins.
- `InfoWindow` is offset upward by `PIN_HEIGHT` pixels via `pixelOffset` so its stem aligns with the top of the pin rather than the tip (the lat/lng point). The offset is derived from the `PIN_HEIGHT` constant so pin size and info window placement stay in sync.

## Test plan

- [x] Pins render as teardrops, not circles, and their tips touch the business location on the map
- [x] Clicking a pin opens the info window with its stem pointing to the top of the pin
- [x] The active pin gets a colored glow and thicker outline; other pins remain normal
- [x] Clicking another pin deactivates the first (both visually and info window)
- [x] Pins with each policy color (green/yellow/red/gray) look correct in both active and inactive states