### PR TITLE
Cap zoom at 17 when fitting map viewport to results

### DIFF
--- a/tipical-frontend/src/components/map/GoogleMap.tsx
+++ b/tipical-frontend/src/components/map/GoogleMap.tsx
@@ -35,12 +35,15 @@ function MapController({ businesses }: { businesses: Business[] }) {
     businesses.forEach(b => bounds.extend({ lat: b.latitude, lng: b.longitude }));
     map.fitBounds(bounds, 80);
 
+    const MAX_FIT_ZOOM = 17;
     const listener = map.addListener('idle', () => {
       listener.remove();
       const c = map.getCenter();
       const z = map.getZoom();
       if (c && z !== undefined) {
-        syncButtonBase({ latitude: c.lat(), longitude: c.lng(), zoom: z });
+        const clampedZoom = Math.min(z, MAX_FIT_ZOOM);
+        if (clampedZoom !== z) map.setZoom(clampedZoom);
+        syncButtonBase({ latitude: c.lat(), longitude: c.lng(), zoom: clampedZoom });
       }
     });
 


### PR DESCRIPTION
After `fitBounds` resolves, the zoom is clamped to a max of 17 (similar to Google Maps autocomplete for specific addresses) so tightly clustered or single results don't zoom in too close.

Closes #161.
