### PR TITLE
Auto-open info window when autocomplete suggestion is accepted

### DIFF
--- a/tipical-frontend/src/App.tsx
+++ b/tipical-frontend/src/App.tsx
@@ -51,6 +51,7 @@ function AppLayout({ initialCenter, initialZoom }: AppLayoutProps) {
         isSearching={isLoading || isPlaceholderData}
         initialCenter={initialCenter}
         initialZoom={initialZoom}
+        placeId={placeId}
         searchBarSlot={<SearchBar />}
         userProfileSlot={<UserProfile />}
       />

--- a/tipical-frontend/src/components/map/GoogleMap.tsx
+++ b/tipical-frontend/src/components/map/GoogleMap.tsx
@@ -15,6 +15,7 @@ interface GoogleMapProps {
   isSearching?: boolean;
   initialCenter: { lat: number; lng: number };
   initialZoom: number;
+  placeId?: string | null;
   searchBarSlot?: React.ReactNode;
   userProfileSlot?: React.ReactNode;
 }
@@ -130,13 +131,18 @@ function MyLocationButton({ latitude, longitude, gpsLoading, requestLocation }: 
   );
 }
 
-export function GoogleMap({ businesses = [], isSearching = false, initialCenter, initialZoom, searchBarSlot, userProfileSlot }: GoogleMapProps) {
+export function GoogleMap({ businesses = [], isSearching = false, initialCenter, initialZoom, placeId, searchBarSlot, userProfileSlot }: GoogleMapProps) {
   const closeBusinessPanel = useUIStore(s => s.closeBusinessPanel);
   const [center, setCenter] = useState(initialCenter);
   const [zoom, setZoom] = useState(initialZoom);
   const [activeMarkerId, setActiveMarkerId] = useState<string | null>(null);
   const [tilesLoaded, setTilesLoaded] = useState(false);
   const { isSupported, latitude, longitude, isLoading: gpsLoading, requestLocation } = useGeolocation();
+
+  useEffect(() => {
+    setActiveMarkerId(placeId ?? null);
+    if (!placeId) closeBusinessPanel();
+  }, [placeId, closeBusinessPanel]);
 
   const handleMapClick = useCallback(() => {
     setActiveMarkerId(null);


### PR DESCRIPTION
Closes #163

When a user accepts an autocomplete suggestion, `setPlaceId` was called on the search store, triggering a place-specific API search — but `activeMarkerId` in `GoogleMap` was never set, so no info window appeared.

## Changes

- `GoogleMap` accepts a new `placeId` prop
- A `useEffect` watches `[placeId, businesses]`: when `placeId` is set and the matching business arrives in the results, `activeMarkerId` is set to that business's `googlePlaceId`, opening the info window exactly as if the pin had been clicked
- When `placeId` is cleared (e.g. user hits ✕), `activeMarkerId` is reset to `null`
- `AppLayout` passes `placeId` down to `GoogleMap`

## Test plan

- [ ] Type an address or business in the search bar, select a suggestion from the dropdown — info window should open automatically on the result pin
- [ ] Press Enter to select the highlighted suggestion — same behavior
- [ ] Click ✕ to clear the search — info window should close
- [ ] Clicking a pin manually still opens/closes the info window as before
- [ ] Area search (submit without selecting a suggestion) still shows no auto-opened info window
