### PR TITLE
Show "No reports" badge for businesses without reports in info window

### DIFF
--- a/tipical-backend/src/Tipical.Api/Program.cs
+++ b/tipical-backend/src/Tipical.Api/Program.cs
@@ -15,7 +15,10 @@ using Tipical.Infrastructure.Services;
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+        options.JsonSerializerOptions.DefaultIgnoreCondition =
+            System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull);
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(c =>
 {

--- a/tipical-frontend/src/components/map/BusinessInfoWindow.tsx
+++ b/tipical-frontend/src/components/map/BusinessInfoWindow.tsx
@@ -116,8 +116,8 @@ export function BusinessInfoWindow({ business, onClose }: BusinessInfoWindowProp
             {POLICY_LABELS[business.winningPolicy]}
           </span>
         ) : (
-          <span className="inline-block text-xs font-medium px-2 py-0.5 rounded-full bg-gray-100 text-gray-600">
-            No data yet
+          <span className={`inline-block text-xs font-medium px-2 py-0.5 rounded-full ${POLICY_BADGE_STYLES.unknown}`}>
+            No reports
           </span>
         )}
 

--- a/tipical-frontend/src/utils/policy.ts
+++ b/tipical-frontend/src/utils/policy.ts
@@ -7,10 +7,11 @@ export const POLICY_LABELS: Record<TipSuggestionType, string> = {
   [TipSuggestion.TipsIncludeTax]: 'Tips on Total',
 };
 
-export const POLICY_BADGE_STYLES: Record<TipSuggestionType, string> = {
+export const POLICY_BADGE_STYLES: Record<TipSuggestionType | 'unknown', string> = {
   [TipSuggestion.NoTips]: 'bg-green-100 text-green-800',
   [TipSuggestion.TipsExcludeTax]: 'bg-yellow-100 text-yellow-800',
   [TipSuggestion.TipsIncludeTax]: 'bg-red-100 text-red-800',
+  unknown: 'bg-gray-100 text-gray-600',
 };
 
 export const POLICY_HEX_COLORS: Record<TipSuggestionType | 'unknown', string> = {


### PR DESCRIPTION
## Summary

- Configures the backend JSON serializer to omit null fields (`WhenWritingNull`), making the API conform to the existing frontend types (`TipSuggestion | undefined`) rather than returning `null` for missing policies
- Updates the gray fallback badge label in the info window from "No data yet" to "No reports" for consistency with app-wide terminology

The root cause was a mismatch between the backend (nullable C# enum serialized as `null`) and the frontend types (`TipSuggestion | undefined`, no `null`). The `!== undefined` guard in `BusinessInfoWindow` passed for `null`, causing `POLICY_BADGE_STYLES[null]` and `POLICY_LABELS[null]` to return `undefined` and render an invisible empty span instead of the gray fallback badge.

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)
