### PR TITLE
Keep info window open when clicking Sign in / Report

### DIFF
--- a/tipical-frontend/src/components/map/BusinessInfoWindow.tsx
+++ b/tipical-frontend/src/components/map/BusinessInfoWindow.tsx
@@ -8,10 +8,9 @@ import { POLICY_LABELS, POLICY_BADGE_STYLES } from '../../utils/policy';
 
 interface BusinessInfoWindowProps {
   business: Business;
-  onClose: () => void;
 }
 
-export function BusinessInfoWindow({ business, onClose }: BusinessInfoWindowProps) {
+export function BusinessInfoWindow({ business }: BusinessInfoWindowProps) {
   const openBusinessPanel = useUIStore(s => s.openBusinessPanel);
   const setShowAuthModal = useUIStore(s => s.setShowAuthModal);
   const isAuthenticated = useAuthStore(s => !!s.token);
@@ -21,7 +20,6 @@ export function BusinessInfoWindow({ business, onClose }: BusinessInfoWindowProp
   const photos = detail?.photos ?? [];
 
   const handleCTA = () => {
-    onClose();
     if (isAuthenticated) {
       openBusinessPanel(business);
     } else {

--- a/tipical-frontend/src/components/map/GoogleMap.tsx
+++ b/tipical-frontend/src/components/map/GoogleMap.tsx
@@ -146,7 +146,7 @@ const MapMarkers = memo(function MapMarkers({ businesses, activeMarkerId, disabl
           disableAutoPan={disableAutoPan || undefined}
           zIndex={50}
         >
-          <BusinessInfoWindow business={activeBusiness} onClose={onInfoWindowClose} />
+          <BusinessInfoWindow business={activeBusiness} />
         </InfoWindow>
       )}
     </>


### PR DESCRIPTION
Fixes #174.

`handleCTA` was calling `onClose()` unconditionally before opening the auth modal or side panel, causing the info window to disappear. Removing that call keeps the info window visible while the user interacts with either flow.

Also removes the now-unused `onClose` prop from `BusinessInfoWindow`.
