### PR TITLE
Add anonymous suggestion box (floating comment icon, lower-left)

### DIFF
--- a/tipical-backend/src/Tipical.Api/Controllers/SuggestionsController.cs
+++ b/tipical-backend/src/Tipical.Api/Controllers/SuggestionsController.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using Tipical.Core.DTOs;
+using Tipical.Core.Services;
+
+namespace Tipical.Api.Controllers;
+
+[ApiController]
+[Route("api/v1/suggestions")]
+public class SuggestionsController(ISuggestionService suggestionService) : ControllerBase
+{
+    /// <summary>Submit an anonymous suggestion.</summary>
+    [HttpPost]
+    [EnableRateLimiting("suggestions")]
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status429TooManyRequests)]
+    public async Task<IActionResult> Submit([FromBody] SuggestionRequest request)
+    {
+        await suggestionService.SubmitAsync(request.Body);
+        return StatusCode(StatusCodes.Status201Created);
+    }
+}

--- a/tipical-backend/src/Tipical.Api/Program.cs
+++ b/tipical-backend/src/Tipical.Api/Program.cs
@@ -1,10 +1,12 @@
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.RateLimiting;
 using Tipical.Api;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi;
 using System.Reflection;
 using System.Text;
+using System.Threading.RateLimiting;
 using Tipical.Core.Repositories;
 using Tipical.Core.Services;
 using Tipical.Core.Models;
@@ -81,6 +83,18 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 
 builder.Services.AddAuthorization();
 
+builder.Services.AddRateLimiter(options =>
+{
+    options.AddFixedWindowLimiter("suggestions", opt =>
+    {
+        opt.PermitLimit = 5;
+        opt.Window = TimeSpan.FromMinutes(1);
+        opt.QueueProcessingOrder = QueueProcessingOrder.OldestFirst;
+        opt.QueueLimit = 0;
+    });
+    options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+});
+
 builder.Services.Configure<AllowedUsersOptions>(builder.Configuration.GetSection("AllowedUsers"));
 
 // Configure CORS
@@ -99,12 +113,14 @@ builder.Services.AddCors(options =>
 // Register repositories
 builder.Services.AddScoped<IBusinessRepository, BusinessRepository>();
 builder.Services.AddScoped<ITippingVoteRepository, TippingVoteRepository>();
+builder.Services.AddScoped<ISuggestionRepository, SuggestionRepository>();
 
 // Register services
 builder.Services.AddScoped<IGooglePlacesService, GooglePlacesService>();
 builder.Services.AddScoped<IGoogleAuthService, GoogleAuthService>();
 builder.Services.AddScoped<IBusinessService, BusinessService>();
 builder.Services.AddScoped<ITippingService, TippingService>();
+builder.Services.AddScoped<ISuggestionService, SuggestionService>();
 
 var app = builder.Build();
 
@@ -128,6 +144,7 @@ app.UseExceptionHandler(errorApp =>
 
 app.UseHttpsRedirection();
 app.UseCors();
+app.UseRateLimiter();
 app.UseAuthentication();
 app.UseAuthorization();
 app.MapControllers();

--- a/tipical-backend/src/Tipical.Core/DTOs/SuggestionDTOs.cs
+++ b/tipical-backend/src/Tipical.Core/DTOs/SuggestionDTOs.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Tipical.Core.DTOs;
+
+public class SuggestionRequest
+{
+    [Required]
+    [MaxLength(2000)]
+    [RegularExpression(@".*\S.*", ErrorMessage = "Body must contain at least one non-whitespace character.")]
+    public string Body { get; set; } = null!;
+}

--- a/tipical-backend/src/Tipical.Core/Models/Suggestion.cs
+++ b/tipical-backend/src/Tipical.Core/Models/Suggestion.cs
@@ -1,0 +1,8 @@
+namespace Tipical.Core.Models;
+
+public class Suggestion
+{
+    public Guid Id { get; set; }
+    public string Body { get; set; } = null!;
+    public DateTimeOffset CreatedAt { get; set; }
+}

--- a/tipical-backend/src/Tipical.Core/Repositories/ISuggestionRepository.cs
+++ b/tipical-backend/src/Tipical.Core/Repositories/ISuggestionRepository.cs
@@ -1,0 +1,8 @@
+using Tipical.Core.Models;
+
+namespace Tipical.Core.Repositories;
+
+public interface ISuggestionRepository
+{
+    Task AddAsync(Suggestion suggestion);
+}

--- a/tipical-backend/src/Tipical.Core/Services/ISuggestionService.cs
+++ b/tipical-backend/src/Tipical.Core/Services/ISuggestionService.cs
@@ -1,0 +1,6 @@
+namespace Tipical.Core.Services;
+
+public interface ISuggestionService
+{
+    Task SubmitAsync(string body);
+}

--- a/tipical-backend/src/Tipical.Infrastructure/Data/ApplicationDbContext.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Data/ApplicationDbContext.cs
@@ -8,6 +8,7 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
     public DbSet<AllowedUser> AllowedUsers { get; set; }
     public DbSet<Business> Businesses { get; set; }
     public DbSet<TippingVote> TippingVotes { get; set; }
+    public DbSet<Suggestion> Suggestions { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/tipical-backend/src/Tipical.Infrastructure/Data/Configurations/SuggestionConfiguration.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Data/Configurations/SuggestionConfiguration.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Tipical.Core.Models;
+
+namespace Tipical.Infrastructure.Data.Configurations;
+
+public class SuggestionConfiguration : IEntityTypeConfiguration<Suggestion>
+{
+    public void Configure(EntityTypeBuilder<Suggestion> builder)
+    {
+        builder.ToTable("suggestions");
+
+        builder.HasKey(s => s.Id);
+
+        builder.Property(s => s.Id)
+            .HasColumnName("id")
+            .ValueGeneratedOnAdd()
+            .HasDefaultValueSql("uuidv7()");
+
+        builder.Property(s => s.Body)
+            .HasColumnName("body")
+            .HasMaxLength(2000)
+            .IsRequired();
+
+        builder.Property(s => s.CreatedAt)
+            .HasColumnName("created_at")
+            .HasDefaultValueSql("CURRENT_TIMESTAMP");
+    }
+}

--- a/tipical-backend/src/Tipical.Infrastructure/Migrations/20260627174830_AddSuggestionsTable.Designer.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Migrations/20260627174830_AddSuggestionsTable.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -13,9 +14,11 @@ using Tipical.Infrastructure.Data;
 namespace Tipical.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260627174830_AddSuggestionsTable")]
+    partial class AddSuggestionsTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/tipical-backend/src/Tipical.Infrastructure/Migrations/20260627174830_AddSuggestionsTable.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Migrations/20260627174830_AddSuggestionsTable.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tipical.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSuggestionsTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "suggestions",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "uuidv7()"),
+                    body = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: false),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_suggestions", x => x.id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "suggestions");
+        }
+    }
+}

--- a/tipical-backend/src/Tipical.Infrastructure/Repositories/SuggestionRepository.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Repositories/SuggestionRepository.cs
@@ -1,0 +1,14 @@
+using Tipical.Core.Models;
+using Tipical.Core.Repositories;
+using Tipical.Infrastructure.Data;
+
+namespace Tipical.Infrastructure.Repositories;
+
+public class SuggestionRepository(ApplicationDbContext context) : ISuggestionRepository
+{
+    public async Task AddAsync(Suggestion suggestion)
+    {
+        context.Suggestions.Add(suggestion);
+        await context.SaveChangesAsync();
+    }
+}

--- a/tipical-backend/src/Tipical.Infrastructure/Services/SuggestionService.cs
+++ b/tipical-backend/src/Tipical.Infrastructure/Services/SuggestionService.cs
@@ -1,0 +1,14 @@
+using Tipical.Core.Models;
+using Tipical.Core.Repositories;
+using Tipical.Core.Services;
+
+namespace Tipical.Infrastructure.Services;
+
+public class SuggestionService(ISuggestionRepository suggestionRepository) : ISuggestionService
+{
+    public async Task SubmitAsync(string body)
+    {
+        var suggestion = new Suggestion { Body = body };
+        await suggestionRepository.AddAsync(suggestion);
+    }
+}

--- a/tipical-frontend/src/App.tsx
+++ b/tipical-frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { BusinessDetailPanel } from './components/business';
 import { UserProfile, GoogleAuthModal } from './components/auth';
 import { Loading } from './components/common';
 import { useUIStore } from './stores/uiStore';
+import { SuggestionBox } from './components/SuggestionBox';
 import type { Business } from './types';
 
 function accuracyToZoom(accuracy: number): number {
@@ -58,6 +59,7 @@ function AppLayout({ initialCenter, initialZoom }: AppLayoutProps) {
 
       <BusinessDetailPanelWrapper />
       <GoogleAuthModal />
+      <SuggestionBox />
     </div>
   );
 }

--- a/tipical-frontend/src/components/SuggestionBox.tsx
+++ b/tipical-frontend/src/components/SuggestionBox.tsx
@@ -1,0 +1,109 @@
+import { useState, useEffect, useRef } from 'react';
+import { submitSuggestion } from '../services/suggestionService';
+
+type Phase = 'idle' | 'open' | 'submitting' | 'thanks' | 'done';
+
+const MAX_CHARS = 2000;
+
+export function SuggestionBox() {
+  const [phase, setPhase] = useState<Phase>('idle');
+  const [text, setText] = useState('');
+  const [error, setError] = useState('');
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const dismiss = () => { setPhase('idle'); setError(''); };
+
+  useEffect(() => {
+    if (phase === 'open') textareaRef.current?.focus();
+  }, [phase]);
+
+  useEffect(() => {
+    if (phase !== 'thanks') return;
+    const id = setTimeout(() => setPhase('done'), 3000);
+    return () => clearTimeout(id);
+  }, [phase]);
+
+  // Document-level Escape listener so it works regardless of which element has focus.
+  useEffect(() => {
+    if (phase !== 'open') return;
+    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') dismiss(); };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [phase]);
+
+  const handleSubmit = async () => {
+    const trimmed = text.trim();
+    if (!trimmed) { setError('Please enter a suggestion.'); return; }
+    setError('');
+    setPhase('submitting');
+    try {
+      await submitSuggestion(trimmed);
+      setPhase('thanks');
+    } catch {
+      setPhase('open');
+      setError('Something went wrong. Please try again.');
+    }
+  };
+
+  if (phase === 'done') return null;
+
+  if (phase === 'thanks') {
+    return (
+      <div
+        className="fixed bottom-12 left-12 z-50 bg-green-600 text-white text-sm font-medium px-4 py-2.5 rounded-lg shadow-lg animate-fade-out"
+        role="status"
+        aria-live="polite"
+      >
+        Thanks for the feedback!
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {(phase === 'open' || phase === 'submitting') && (
+        <div className="fixed inset-0 z-40" onClick={dismiss} aria-hidden="true" />
+      )}
+
+      <div className="fixed bottom-12 left-12 z-50 flex flex-col items-start gap-2">
+        {phase === 'open' && (
+          <div className="bg-white rounded-xl shadow-xl w-72 p-3 flex flex-col gap-2">
+            <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide">Send anonymous feedback</p>
+            <textarea
+              ref={textareaRef}
+              value={text}
+              onChange={e => { setText(e.target.value); setError(''); }}
+              placeholder="Share a suggestion or report an issue…"
+              maxLength={MAX_CHARS}
+              rows={4}
+              className="w-full resize-none rounded-lg border border-gray-200 p-2 text-sm text-gray-800 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-gray-400">{text.length}/{MAX_CHARS}</span>
+              {error && <span className="text-xs text-red-500">{error}</span>}
+            </div>
+            <button
+              onClick={handleSubmit}
+              className="w-full rounded-lg bg-blue-600 py-1.5 text-sm font-semibold text-white hover:bg-blue-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            >
+              Submit
+            </button>
+          </div>
+        )}
+
+        <button
+          onClick={() => { if (phase !== 'submitting') setPhase(p => p === 'open' ? 'idle' : 'open'); }}
+          disabled={phase === 'submitting'}
+          title={phase === 'open' ? 'Close suggestion box' : 'Send feedback'}
+          aria-label={phase === 'open' ? 'Close suggestion box' : 'Send feedback'}
+          aria-expanded={phase === 'open'}
+          className="bg-white rounded-full shadow-md p-2.5 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8} aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M7 8h10M7 12h6m-8 8l4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2H9l-4 4z" />
+          </svg>
+        </button>
+      </div>
+    </>
+  );
+}

--- a/tipical-frontend/src/index.css
+++ b/tipical-frontend/src/index.css
@@ -4,3 +4,13 @@ body {
   margin: 0;
   font-family: system-ui, -apple-system, sans-serif;
 }
+
+@keyframes fade-out {
+  0% { opacity: 1; transform: translateY(0); }
+  70% { opacity: 1; transform: translateY(0); }
+  100% { opacity: 0; transform: translateY(4px); }
+}
+
+@utility animate-fade-out {
+  animation: fade-out 3s ease-in-out forwards;
+}

--- a/tipical-frontend/src/services/suggestionService.ts
+++ b/tipical-frontend/src/services/suggestionService.ts
@@ -1,0 +1,5 @@
+import { apiClient } from './api';
+
+export async function submitSuggestion(body: string): Promise<void> {
+  await apiClient.post('/suggestions', { body });
+}


### PR DESCRIPTION
Closes #176

## Summary

- New `suggestions` table (`id` UUID v7, `body` varchar(2000), `created_at`) with EF Core migration and full clean-arch wiring (model → config → repo interface → repo impl → service interface → service impl → controller)
- `POST /api/v1/suggestions` — anonymous, no auth required, validates body is non-empty and ≤ 2000 chars
- `SuggestionBox` React component: floating chat icon fixed to the lower-left of the map; clicking expands a textarea panel; Escape or clicking again collapses it
- On submit, the panel/icon is replaced by a "Thanks for the feedback!" toast that fades out after 3 seconds, then unmounts
- `animate-fade-out` keyframe added to `index.css` (Tailwind v4 `@utility`)

## Test plan

- [x] Run migration: `dotnet ef database update --project src/Tipical.Infrastructure --startup-project src/Tipical.Api`
- [x] Start backend and confirm `POST /api/v1/suggestions` returns 201 with `{"body":"test"}` (no auth header needed)
- [x] Confirm row appears in `suggestions` table
- [x] Start frontend — chat icon should be visible in the lower-left corner
- [x] Click icon → suggestion panel expands
- [x] Press Escape → panel collapses
- [x] Submit an empty suggestion → inline error message shown, no request sent
- [x] Submit a valid suggestion → "Thanks for the feedback!" toast appears and auto-dismisses in ~3 seconds
- [x] After dismissal the icon is gone for the session
- [x] Confirm no auth token is sent in the request (works when signed out)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
