### PR TITLE
Fix deploy-test Firebase auth: pin Node 24.18.0 via Volta

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: lts/*
+          node-version-file: tipical-frontend/package.json
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -126,7 +126,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: lts/*
+          node-version-file: tipical-frontend/package.json
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/tipical-frontend/package.json
+++ b/tipical-frontend/package.json
@@ -38,5 +38,8 @@
     "typescript": "~6.0.3",
     "typescript-eslint": "^8.62.0",
     "vite": "^8.1.0"
+  },
+  "volta": {
+    "node": "24.18.0"
   }
 }


### PR DESCRIPTION
## Summary

- Adds Volta to `tipical-frontend/package.json`, pinning Node to `24.18.0`
- Switches `ci.yml` and `deploy-test.yml` from `node-version: lts/*` to `node-version-file: tipical-frontend/package.json` (read via the `volta.node` field)

## Why

Node 22.23.0 and 24.17.0 introduced a keep-alive socket regression in `http.Agent` that breaks `google-auth-library`'s ADC / WIF credential exchange, causing Firebase deploys to fail with `"Failed to authenticate, have you run firebase login?"` despite `GOOGLE_APPLICATION_CREDENTIALS` being correctly set. PR #180 added `actions/setup-node` with `node-version: lts/*`, which was resolving to an affected Node version.

Node 24.18.0 is the first patched release ([firebase/firebase-tools#10716](https://github.com/firebase/firebase-tools/issues/10716)).

To upgrade Node in future: run `volta pin node@lts` in `tipical-frontend/` and commit.

Closes #183.

## Test plan

- [ ] `deploy-test` workflow succeeds after merge (Firebase Hosting deploy authenticates via WIF)
- [ ] `CI` workflow passes on Node 24.18.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
