### PR TITLE
Add deploy-prod.yml GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '10.x'
+          dotnet-version: '10.0.x'
 
       - name: Restore
         run: dotnet restore tipical-backend/Tipical.sln

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,11 +1,15 @@
-name: Deploy to Test
+name: Deploy to Production
 
 on:
-  push:
-    branches: [main]
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Git SHA already deployed to and validated on test'
+        required: true
+        type: string
 
 concurrency:
-  group: deploy-test
+  group: deploy-prod
   cancel-in-progress: false
 
 permissions:
@@ -16,14 +20,12 @@ env:
   REGION: us-central1
 
 jobs:
-  build-and-push-image:
-    name: Build and Push Image
+  validate-tag:
+    name: Validate Tag
     runs-on: ubuntu-latest
     outputs:
       image: ${{ steps.meta.outputs.image }}
     steps:
-      - uses: actions/checkout@v6
-
       - uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
@@ -33,21 +35,37 @@ jobs:
         with:
           project_id: ${{ vars.GCP_PROJECT_ID }}
 
-      - name: Configure Docker for Artifact Registry
-        run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
-
       - id: meta
-        run: echo "image=us-central1-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/tipical/api:${{ github.sha }}" >> $GITHUB_OUTPUT
+        name: Set image ref
+        env:
+          IMAGE_TAG: ${{ inputs.image_tag }}
+        run: echo "image=us-central1-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/tipical/api:${IMAGE_TAG}" >> $GITHUB_OUTPUT
 
-      - name: Build and push
+      - name: Confirm image exists in Artifact Registry
+        id: ar_check
         run: |
-          docker build -t ${{ steps.meta.outputs.image }} tipical-backend/
-          docker push ${{ steps.meta.outputs.image }}
+          DIGEST=$(gcloud artifacts docker images describe "${{ steps.meta.outputs.image }}" \
+            --format 'value(image_summary.digest)' --quiet)
+          echo "digest=$DIGEST" >> $GITHUB_OUTPUT
 
-  run-migrations-test:
-    name: Run Migrations (Test)
-    needs: build-and-push-image
+      - name: Confirm image is deployed on test
+        env:
+          EXPECTED_DIGEST: ${{ steps.ar_check.outputs.digest }}
+        run: |
+          DEPLOYED=$(gcloud run services describe tipical-api-test \
+            --region ${{ env.REGION }} \
+            --format 'value(spec.template.spec.containers[0].image)')
+          if [[ "$DEPLOYED" != *"$EXPECTED_DIGEST"* ]]; then
+            echo "Deployed image does not match expected (deployed: $DEPLOYED, expected digest: $EXPECTED_DIGEST)"
+            exit 1
+          fi
+          echo "Confirmed: $EXPECTED_DIGEST is deployed on tipical-api-test"
+
+  run-migrations-prod:
+    name: Run Migrations (Prod)
+    needs: validate-tag
     runs-on: ubuntu-latest
+    environment: prod
     steps:
       - uses: google-github-actions/auth@v3
         with:
@@ -58,34 +76,24 @@ jobs:
         with:
           project_id: ${{ vars.GCP_PROJECT_ID }}
 
-      - name: Create or update migration job
+      - name: Update migration job image
         run: |
-          if gcloud run jobs describe tipical-migrate-test --region ${{ env.REGION }} >/dev/null 2>&1; then
-            gcloud run jobs update tipical-migrate-test \
-              --image ${{ needs.build-and-push-image.outputs.image }} \
-              --region ${{ env.REGION }}
-          else
-            gcloud run jobs create tipical-migrate-test \
-              --image ${{ needs.build-and-push-image.outputs.image }} \
-              --command /app/efbundle \
-              --region ${{ env.REGION }} \
-              --set-secrets ConnectionStrings__DefaultConnection=test-db-connection-string:latest \
-              --set-cloudsql-instances ${{ vars.GCP_PROJECT_ID }}:${{ env.REGION }}:tipical-db-test \
-              --service-account tipical-api-test@${{ vars.GCP_PROJECT_ID }}.iam.gserviceaccount.com \
-              --max-retries 0
-          fi
+          gcloud run jobs update tipical-migrate-prod \
+            --image ${{ needs.validate-tag.outputs.image }} \
+            --region ${{ env.REGION }} \
+            --max-retries 0
 
       - name: Execute migrations
         run: |
-          gcloud run jobs execute tipical-migrate-test \
+          gcloud run jobs execute tipical-migrate-prod \
             --region ${{ env.REGION }} \
             --wait
 
-  deploy-api-test:
-    name: Deploy API (Test)
-    needs: [build-and-push-image, run-migrations-test]
+  deploy-api-prod:
+    name: Deploy API (Prod)
+    needs: [validate-tag, run-migrations-prod]
     runs-on: ubuntu-latest
-    environment: test
+    environment: prod
     outputs:
       url: ${{ steps.deploy.outputs.url }}
     steps:
@@ -101,28 +109,30 @@ jobs:
       - name: Deploy to Cloud Run
         id: deploy
         run: |
-          gcloud run deploy tipical-api-test \
-            --image ${{ needs.build-and-push-image.outputs.image }} \
+          gcloud run deploy tipical-api-prod \
+            --image ${{ needs.validate-tag.outputs.image }} \
             --region ${{ env.REGION }} \
-            --add-cloudsql-instances ${{ vars.GCP_PROJECT_ID }}:${{ env.REGION }}:tipical-db-test \
-            --set-secrets "ConnectionStrings__DefaultConnection=test-db-connection-string:latest,GooglePlaces__ApiKey=test-google-places-api-key:latest,GoogleOAuth__ClientId=test-google-oauth-client-id:latest,JwtSettings__Secret=test-jwt-secret:latest" \
-            --set-env-vars "^|^ASPNETCORE_ENVIRONMENT=Production|Cors__AllowedOrigins__0=https://tipical-test.web.app|AllowedUsers__Enabled=${{ vars.ALLOWED_USERS_ENABLED }}" \
-            --service-account tipical-api-test@${{ vars.GCP_PROJECT_ID }}.iam.gserviceaccount.com \
+            --add-cloudsql-instances ${{ vars.GCP_PROJECT_ID }}:${{ env.REGION }}:tipical-db-prod \
+            --set-secrets "ConnectionStrings__DefaultConnection=prod-db-connection-string:latest,GooglePlaces__ApiKey=prod-google-places-api-key:latest,GoogleOAuth__ClientId=prod-google-oauth-client-id:latest,JwtSettings__Secret=prod-jwt-secret:latest" \
+            --set-env-vars "^|^ASPNETCORE_ENVIRONMENT=Production|Cors__AllowedOrigins__0=https://tipical.web.app|AllowedUsers__Enabled=${{ vars.ALLOWED_USERS_ENABLED }}" \
+            --service-account tipical-api-prod@${{ vars.GCP_PROJECT_ID }}.iam.gserviceaccount.com \
             --allow-unauthenticated \
             --quiet
 
-          URL=$(gcloud run services describe tipical-api-test \
+          URL=$(gcloud run services describe tipical-api-prod \
             --region ${{ env.REGION }} \
             --format 'value(status.url)')
           echo "url=$URL" >> $GITHUB_OUTPUT
 
-  build-and-deploy-frontend-test:
-    name: Build and Deploy Frontend (Test)
-    needs: deploy-api-test
+  build-and-deploy-frontend-prod:
+    name: Build and Deploy Frontend (Prod)
+    needs: deploy-api-prod
     runs-on: ubuntu-latest
-    environment: test
+    environment: prod
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.image_tag }}
 
       - uses: pnpm/action-setup@v4
         with:
@@ -154,17 +164,17 @@ jobs:
         run: npm install -g firebase-tools@15.22.3
 
       - name: Deploy to Firebase Hosting
-        run: firebase deploy --only hosting:tipical-test
+        run: firebase deploy --only hosting:tipical
 
-  smoke-test-test:
-    name: Smoke Test (Test)
-    needs: [build-and-deploy-frontend-test, deploy-api-test]
+  smoke-test-prod:
+    name: Smoke Test (Prod)
+    needs: [build-and-deploy-frontend-prod, deploy-api-prod]
     runs-on: ubuntu-latest
     steps:
       - name: Smoke test
         run: |
           STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-            "${{ needs.deploy-api-test.outputs.url }}/api/v1/businesses/search?latitude=47.6062&longitude=-122.3321&radius=5000")
+            "${{ needs.deploy-api-prod.outputs.url }}/api/v1/businesses/search?latitude=47.6062&longitude=-122.3321&radius=5000")
           if [ "$STATUS" != "200" ]; then
             echo "Smoke test failed: expected 200, got $STATUS"
             exit 1

--- a/tipical-backend/global.json
+++ b/tipical-backend/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.102",
+    "rollForward": "latestPatch"
+  }
+}


### PR DESCRIPTION
Closes #39

## Summary
- Adds `.github/workflows/deploy-prod.yml` — manually triggered via `workflow_dispatch` with a required `image_tag` (git SHA) input
- `validate-tag` fetches the image digest from Artifact Registry and confirms that digest is currently deployed on `tipical-api-test` (digest comparison accounts for Cloud Run resolving tags to digests at deploy time); fails fast if either check fails
- `run-migrations-prod` is the first job to reference the `prod` environment (required reviewer gate), updates `tipical-migrate-prod` to the validated image with `--max-retries 0`, then executes with `--wait`
- `deploy-api-prod` deploys `tipical-api-prod` with all `prod-*` secrets and prod env vars
- `build-and-deploy-frontend-prod` checks out the exact `image_tag` SHA, builds with `prod` environment vars, deploys to Firebase Hosting target `tipical`
- `smoke-test-prod` curls `GET /api/v1/businesses/search` against the prod Cloud Run URL and asserts HTTP 200
- `concurrency: cancel-in-progress: false` on both `deploy-prod.yml` and `deploy-test.yml` to serialize concurrent triggers

Also includes a dependency pinning sweep:
- `firebase-tools` pinned to `15.22.3` in both `deploy-prod.yml` and `deploy-test.yml`
- `dotnet-version` in `ci.yml` narrowed from `10.x` to `10.0.x`
- `tipical-backend/global.json` added, pinning the .NET SDK to `10.0.102` (`rollForward: latestPatch`)

## Test plan
- [ ] Trigger workflow with a SHA that does not exist in Artifact Registry — expect `validate-tag` to fail
- [ ] Trigger workflow with a valid SHA not currently deployed on test — expect `validate-tag` to fail
- [ ] Trigger workflow with the SHA currently deployed on test — reviewer approval gate appears before migrations run
- [ ] After approval, verify migrations execute, API deploys, frontend deploys to `tipical`, and smoke test passes
- [ ] Trigger workflow twice in quick succession — second run should queue, not race
