### PR TITLE
Remove global.json; keep ci.yml pinned to 10.0.x

### DIFF
--- a/tipical-backend/global.json
+++ b/tipical-backend/global.json
@@ -1,6 +1,0 @@
-{
-  "sdk": {
-    "version": "10.0.102",
-    "rollForward": "latestPatch"
-  }
-}


### PR DESCRIPTION
Fixes #186

## Summary
- Deletes \`tipical-backend/global.json\`

The production binary is built by Docker (\`FROM mcr.microsoft.com/dotnet/sdk:10.0\`), so \`global.json\` has no effect on the deployed artifact — it only applies to direct \`dotnet\` invocations (CI tests, local dev). It broke the Docker build because the \`sdk:10.0\` image had an older \`10.0.1xx\` patch than the \`10.0.102\` floor specified in \`global.json\`.

Removing it also eliminates a maintenance burden: without it, \`ci.yml\`'s \`dotnet-version: '10.0.x'\` already guards against accidentally jumping to a future \`10.1.x\`, and SDK patch differences at that level don't affect test correctness.

## Test plan
- [ ] \`deploy-test.yml\` build-and-push-image job completes successfully