### PR TITLE
Fix validate-tag: compare image refs directly, not digests

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -42,24 +42,20 @@ jobs:
         run: echo "image=us-central1-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/tipical/api:${IMAGE_TAG}" >> $GITHUB_OUTPUT
 
       - name: Confirm image exists in Artifact Registry
-        id: ar_check
-        run: |
-          DIGEST=$(gcloud artifacts docker images describe "${{ steps.meta.outputs.image }}" \
-            --format 'value(image_summary.digest)' --quiet)
-          echo "digest=$DIGEST" >> $GITHUB_OUTPUT
+        run: gcloud artifacts docker images describe "${{ steps.meta.outputs.image }}" --quiet
 
       - name: Confirm image is deployed on test
         env:
-          EXPECTED_DIGEST: ${{ steps.ar_check.outputs.digest }}
+          EXPECTED_IMAGE: ${{ steps.meta.outputs.image }}
         run: |
           DEPLOYED=$(gcloud run services describe tipical-api-test \
             --region ${{ env.REGION }} \
             --format 'value(spec.template.spec.containers[0].image)')
-          if [[ "$DEPLOYED" != *"$EXPECTED_DIGEST"* ]]; then
-            echo "Deployed image does not match expected (deployed: $DEPLOYED, expected digest: $EXPECTED_DIGEST)"
+          if [ "$DEPLOYED" != "$EXPECTED_IMAGE" ]; then
+            echo "Deployed image does not match expected (deployed: $DEPLOYED, expected: $EXPECTED_IMAGE)"
             exit 1
           fi
-          echo "Confirmed: $EXPECTED_DIGEST is deployed on tipical-api-test"
+          echo "Confirmed: $EXPECTED_IMAGE is deployed on tipical-api-test"
 
   run-migrations-prod:
     name: Run Migrations (Prod)


### PR DESCRIPTION
## Bug

Both prod deployment attempts failed in \`validate-tag\`:

\`\`\`
Deployed image does not match expected
  deployed: us-central1-docker.pkg.dev/tipical/tipical/api:e4b1c6add990…
  expected digest: sha256:4bd4dbced62aa575b462422820c4f6a8a77fb4b7f200…
\`\`\`

Runs: https://github.com/gzak/tipical/actions/runs/28354683285, https://github.com/gzak/tipical/actions/runs/28354615094

## Root Cause

The code review on #184 flagged that Cloud Run might resolve image tags to digests at deploy time, making a direct string comparison unreliable. The comparison was changed to use digest matching. In practice, Cloud Run on this project stores the tag-based image ref — so \`DEPLOYED\` is always \`…/api:<sha>\`, never \`…/api@sha256:…\`, and the digest check always fails.

## Fix

Revert to a direct string comparison (\`DEPLOYED == EXPECTED_IMAGE\`), keeping the injection-safe env var pattern for \`steps.meta.outputs.image\`. Simplify the AR check back to a one-liner.

## Test plan
- [ ] Trigger \`deploy-prod.yml\` with the SHA currently deployed on test — \`validate-tag\` passes