### PR TITLE
Bump pinned GitHub Actions to latest stable versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
     name: Build Backend
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 
@@ -33,9 +33,9 @@ jobs:
     name: Build Frontend
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           package_json_file: tipical-frontend/package.json
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -126,11 +126,11 @@ jobs:
     runs-on: ubuntu-latest
     environment: prod
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.image_tag }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           package_json_file: tipical-frontend/package.json
 

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -22,7 +22,7 @@ jobs:
     outputs:
       image: ${{ steps.meta.outputs.image }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: google-github-actions/auth@v3
         with:
@@ -122,9 +122,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: test
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           package_json_file: tipical-frontend/package.json
 


### PR DESCRIPTION
## Summary
- Bump `pnpm/action-setup@v4` → `@v6` in `ci.yml`, `deploy-test.yml`, and `deploy-prod.yml`, fixing the Node.js 20 deprecation warning (#188)
- Bump `actions/checkout@v6` → `@v7` and `actions/setup-dotnet@v4` → `@v5` across all three workflows while auditing other pinned action versions
- `actions/setup-node@v6`, `google-github-actions/auth@v3`, and `google-github-actions/setup-gcloud@v3` were already on their latest major version, so left unchanged

## Test plan
- [x] Confirm `ci.yml` runs green on this PR
- [x] Confirm the Node.js 20 deprecation annotation no longer appears in the job logs

Closes #188
