### PR TITLE
Remove push trigger from ci.yml (redundant with deploy-test)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Summary
- Remove the `push` trigger from `ci.yml`, keeping only `pull_request`
- `deploy-test.yml` already runs on every push to `main` and is a strict superset of CI (builds, pushes the image, runs migrations, deploys, and smoke tests), so the `push` trigger was running two redundant workflows on every merge to `main`

## Test plan
- [x] Confirm CI still runs on this PR (pull_request trigger)
- [x] Confirm `ci.yml` does not run again once this merges to `main`

Closes #190
