### PR TITLE
Centralize NuGet package versions via Directory.Packages.props

### DIFF
--- a/tipical-backend/Directory.Packages.props
+++ b/tipical-backend/Directory.Packages.props
@@ -1,0 +1,25 @@
+<Project>
+
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="FlexLabs.EntityFrameworkCore.Upsert" Version="10.0.0" />
+    <PackageVersion Include="Google.Apis.Auth" Version="1.75.0" />
+    <PackageVersion Include="Google.Maps.Places.V1" Version="1.0.0-beta21" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.OpenApi" Version="2.9.0" />
+    <PackageVersion Include="NetTopologySuite" Version="2.6.0" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="10.0.2" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.3" />
+    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
+    <PackageVersion Include="TUnit" Version="1.56.35" />
+  </ItemGroup>
+
+</Project>

--- a/tipical-backend/Dockerfile
+++ b/tipical-backend/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /src
 # expansion on Linux fails with DirectoryNotFoundException if they're absent,
 # falling back to treating **/*.resx / **/*.cs as literal paths (MSB3552 / CS2001).
 COPY .config/ .config/
+COPY Directory.Packages.props .
 COPY src/Tipical.Api/Tipical.Api.csproj src/Tipical.Api/
 COPY src/Tipical.Core/Tipical.Core.csproj src/Tipical.Core/
 COPY src/Tipical.Infrastructure/Tipical.Infrastructure.csproj src/Tipical.Infrastructure/

--- a/tipical-backend/src/Tipical.Api/Tipical.Api.csproj
+++ b/tipical-backend/src/Tipical.Api/Tipical.Api.csproj
@@ -9,16 +9,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
-    <PackageReference Include="Microsoft.OpenApi" Version="2.9.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
+    <PackageReference Include="Microsoft.OpenApi" />
+    <PackageReference Include="Swashbuckle.AspNetCore" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tipical-backend/src/Tipical.Core/Tipical.Core.csproj
+++ b/tipical-backend/src/Tipical.Core/Tipical.Core.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Maps.Places.V1" Version="1.0.0-beta21" />
-    <PackageReference Include="NetTopologySuite" Version="2.6.0" />
+    <PackageReference Include="Google.Maps.Places.V1" />
+    <PackageReference Include="NetTopologySuite" />
   </ItemGroup>
 
 </Project>

--- a/tipical-backend/src/Tipical.Infrastructure/Tipical.Infrastructure.csproj
+++ b/tipical-backend/src/Tipical.Infrastructure/Tipical.Infrastructure.csproj
@@ -5,17 +5,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FlexLabs.EntityFrameworkCore.Upsert" Version="10.0.0" />
-    <PackageReference Include="Google.Apis.Auth" Version="1.75.0" />
-    <PackageReference Include="Google.Maps.Places.V1" Version="1.0.0-beta21" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
+    <PackageReference Include="FlexLabs.EntityFrameworkCore.Upsert" />
+    <PackageReference Include="Google.Apis.Auth" />
+    <PackageReference Include="Google.Maps.Places.V1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="NetTopologySuite" Version="2.6.0" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="10.0.2" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
+    <PackageReference Include="NetTopologySuite" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/tipical-backend/tests/Tipical.Infrastructure.Tests/Tipical.Infrastructure.Tests.csproj
+++ b/tipical-backend/tests/Tipical.Infrastructure.Tests/Tipical.Infrastructure.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="TUnit" Version="1.56.35" />
+    <PackageReference Include="TUnit" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Add `tipical-backend/Directory.Packages.props` with `ManagePackageVersionsCentrally` enabled, listing every NuGet package version once for all 4 projects in the solution
- Strip the `Version` attribute from every `PackageReference` across `Tipical.Api`, `Tipical.Core`, `Tipical.Infrastructure`, and `Tipical.Infrastructure.Tests`
- Update the Dockerfile to copy `Directory.Packages.props` into the build context before `dotnet restore`, so Docker builds keep working
- `Google.Maps.Places.V1`, `NetTopologySuite`, and `Microsoft.EntityFrameworkCore.Design` were each pinned independently in 2 projects already, in sync only by luck — this gives them one source of truth

## Test plan
- [x] `dotnet restore` / `dotnet build` succeed locally with no version conflicts
- [x] `dotnet run` test suite passes (14/14)
- [x] `docker build` succeeds end-to-end, including the EF migrations bundle stage
- [x] Confirm CI passes on this PR
