### PR TITLE
Update CORS origin and API base URL for tipscape.app

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -110,7 +110,7 @@ jobs:
             --region ${{ env.REGION }} \
             --add-cloudsql-instances ${{ vars.GCP_PROJECT_ID }}:${{ env.REGION }}:tipical-db-prod \
             --set-secrets "ConnectionStrings__DefaultConnection=prod-db-connection-string:latest,GooglePlaces__ApiKey=prod-google-places-api-key:latest,GoogleOAuth__ClientId=prod-google-oauth-client-id:latest,JwtSettings__Secret=prod-jwt-secret:latest" \
-            --set-env-vars "^|^ASPNETCORE_ENVIRONMENT=Production|Cors__AllowedOrigins__0=https://tipical.web.app|AllowedUsers__Enabled=${{ vars.ALLOWED_USERS_ENABLED }}" \
+            --set-env-vars "^|^ASPNETCORE_ENVIRONMENT=Production|Cors__AllowedOrigins__0=https://tipscape.app|AllowedUsers__Enabled=${{ vars.ALLOWED_USERS_ENABLED }}" \
             --service-account tipical-api-prod@${{ vars.GCP_PROJECT_ID }}.iam.gserviceaccount.com \
             --allow-unauthenticated \
             --quiet

--- a/tipical-backend/src/Tipical.Api/Program.cs
+++ b/tipical-backend/src/Tipical.Api/Program.cs
@@ -26,7 +26,7 @@ builder.Services.AddSwaggerGen(c =>
 {
     c.SwaggerDoc("v1", new OpenApiInfo
     {
-        Title = "Tipical API",
+        Title = "TipScape API",
         Version = "v1",
         Description = "Crowd-sourced tipping policy data for local businesses."
     });

--- a/tipical-frontend/index.html
+++ b/tipical-frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>tipical-frontend</title>
+    <title>TipScape</title>
   </head>
   <body>
     <div id="root"></div>

--- a/tipical-frontend/package.json
+++ b/tipical-frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tipical-frontend",
+  "name": "tipscape-frontend",
   "private": true,
   "version": "0.0.0",
   "type": "module",


### PR DESCRIPTION
Closes #196

## Summary
- Updates the prod deploy workflow's CORS origin from `https://tipical.web.app` to `https://tipscape.app`
- Updates the `VITE_API_BASE_URL` GitHub repo variable (prod env) from the Cloud Run default URL to `https://api.tipscape.app/api/v1` (done directly via `gh variable set`, not a file change)
- Renames the frontend `<title>`, Swagger API title, and frontend `package.json` name from "Tipical"/"tipical-frontend" to "TipScape"/"tipscape-frontend"

## Context
Domain/DNS/Firebase/Cloud Run setup is confirmed done in #195.

## Test plan
- [ ] Confirm next prod deploy sets `Cors__AllowedOrigins__0=https://tipscape.app` on Cloud Run
- [ ] Confirm frontend build embeds `https://api.tipscape.app/api/v1` as the API base URL
- [ ] Load `https://tipscape.app` after deploy and confirm no CORS errors
- [ ] Confirm browser tab title reads "TipScape" and Swagger UI title reads "TipScape API"
