### PR TITLE
Stack "Search this area" button to a second row on mobile

### DIFF
--- a/tipical-frontend/src/components/map/SearchThisAreaButton.tsx
+++ b/tipical-frontend/src/components/map/SearchThisAreaButton.tsx
@@ -19,7 +19,7 @@ export function SearchThisAreaButton({ center, zoom, isSearching = false }: Sear
     <button
       onClick={() => setSearchCenter({ latitude: center.lat, longitude: center.lng, zoom })}
       disabled={isSearching}
-      className="m-3 inline-flex items-center gap-2 bg-white text-gray-800 text-sm font-medium px-4 py-2 rounded-full shadow-md hover:bg-gray-50 disabled:hover:bg-white disabled:cursor-not-allowed disabled:opacity-80 transition-colors border border-gray-200"
+      className="mx-3 mb-3 mt-16 md:mt-3 inline-flex items-center gap-2 bg-white text-gray-800 text-sm font-medium px-4 py-2 rounded-full shadow-md hover:bg-gray-50 disabled:hover:bg-white disabled:cursor-not-allowed disabled:opacity-80 transition-colors border border-gray-200"
     >
       {isSearching && (
         <div className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-gray-400 border-t-transparent" aria-hidden="true" />


### PR DESCRIPTION
## Summary
`SearchThisAreaButton.tsx` is rendered in the `TOP_CENTER` `MapControl`, alongside the search
bar (`TOP_LEFT`) and avatar (`TOP_RIGHT`). These are independent Google Maps `MapControl`
overlays rather than flex siblings, so there's no native reflow between them — on mobile the
button's margin didn't leave enough room and it could collide with the search bar/avatar row.

The button's className now uses `mx-3 mb-3 mt-16 md:mt-3` instead of `m-3`:
- Below `md:` (768px, i.e. phone-sized viewports), the button gets a 64px top margin, pushing
  it onto its own row below the search bar/avatar row with a small gap.
- At `md:` and up, the top margin returns to the normal 12px, keeping it inline with the search
  bar/avatar as before.

Closes #201

## Test plan
- [ ] On a mobile-width viewport (< md), confirm the "Search this area" button renders on its
      own row below the search bar/avatar row with no overlap.
- [ ] On tablet/desktop (>= md), confirm the button still sits inline with the search
      bar/avatar row as before.
