### PR TITLE
Narrow SearchBar on mobile to avoid overlapping the profile avatar

### DIFF
--- a/tipical-frontend/src/components/auth/UserProfile.tsx
+++ b/tipical-frontend/src/components/auth/UserProfile.tsx
@@ -2,20 +2,30 @@ import { useState, useRef, useEffect } from 'react';
 import { useAuthStore } from '../../stores/authStore';
 import { useUIStore } from '../../stores/uiStore';
 import { useClickOutside } from '../../hooks/useClickOutside';
-import { Button } from '../common/Button';
 
+// Same w-10 h-10 circle as the signed-in avatar button below, so the
+// TOP_RIGHT control is identically sized/aligned in both auth states.
 const SignInButton = () => {
   const setShowAuthModal = useUIStore(s => s.setShowAuthModal);
   return (
-    <Button
+    <button
       type="button"
-      variant="primary"
-      size="sm"
-      className="!rounded-full"
       onClick={() => setShowAuthModal(true)}
+      className={`
+        flex items-center justify-center
+        w-10 h-10
+        rounded-full
+        bg-gray-400 text-white
+        transition-all duration-200
+        hover:ring-2 hover:ring-gray-300
+        focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2
+      `}
+      aria-label="Sign in"
     >
-      Sign in
-    </Button>
+      <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
+        <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z" />
+      </svg>
+    </button>
   );
 };
 
@@ -76,7 +86,7 @@ const ProfileDropdown = () => {
         onClick={toggleDropdown}
         className={`
           flex items-center justify-center
-          w-9 h-9 sm:w-10 sm:h-10
+          w-10 h-10
           rounded-full
           transition-all duration-200
           focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2

--- a/tipical-frontend/src/components/search/SearchBar.tsx
+++ b/tipical-frontend/src/components/search/SearchBar.tsx
@@ -178,8 +178,12 @@ export function SearchBar() {
     }
   }, [suggestions, activeIndex, selectSuggestion]);
 
+  // 5.5rem (88px) reserves room for the TOP_RIGHT profile/sign-in control, which
+  // is always a fixed `w-10 h-10` circle (see UserProfile.tsx) with `m-2.5`
+  // margin on both sides (GoogleMap.tsx) — a 60px footprint. If that box's size
+  // or margin changes, this value needs to grow to match or the two can overlap.
   return (
-    <div ref={containerRef} className="relative w-full max-w-xl">
+    <div ref={containerRef} className="relative w-[calc(100vw-5.5rem)] max-w-xl">
       <form
         onSubmit={handleSubmit}
         className="flex items-center gap-2 bg-white rounded-xl shadow-lg px-4 py-2"


### PR DESCRIPTION
## Summary
`SearchBar` and the profile avatar are rendered in separate `TOP_LEFT` / `TOP_RIGHT` Google Maps
`MapControl`s, which don't reflow around each other. On narrow viewports the search bar's
`max-w-xl` cap left it wide enough to overlap the avatar.

- `SearchBar.tsx`: width is now `w-[calc(100vw-5.5rem)] md:max-w-xl` — narrow on mobile to leave
  room for the avatar, back to the `max-w-xl` cap at `md:` and up.
- `GoogleMap.tsx`: the `TOP_LEFT` `MapControl` wrapper's margin is `m-2 md:m-2.5`, tightening the
  edge margin on mobile to reclaim a bit more space.

Closes #200

## Test plan
- [x] `npm run lint`
- [x] `npm run build`
- [ ] Manually verify on a narrow viewport that the search bar no longer overlaps the profile avatar
- [ ] Verify the search bar returns to `max-w-xl` at `md:` and up
