### PR TITLE
Make Sidebar full-width on mobile

### DIFF
--- a/tipical-frontend/src/components/common/Sidebar.tsx
+++ b/tipical-frontend/src/components/common/Sidebar.tsx
@@ -39,9 +39,9 @@ export const Sidebar = ({
   }, [isOpen, onClose]);
 
   const widthStyles = {
-    sm: 'w-80',
-    md: 'w-96',
-    lg: 'w-[32rem]',
+    sm: 'md:w-80',
+    md: 'md:w-96',
+    lg: 'md:w-[32rem]',
   };
 
   const positionStyles = {
@@ -67,7 +67,7 @@ export const Sidebar = ({
 
       {/* Sidebar */}
       <div
-        className={`fixed top-0 ${positionStyles[position]} h-full ${widthStyles[width]} bg-white shadow-xl z-50 transform transition-transform duration-300 ease-in-out ${slideAnimation[position]} flex flex-col`}
+        className={`fixed top-0 ${positionStyles[position]} h-full w-full ${widthStyles[width]} bg-white shadow-xl z-50 transform transition-transform duration-300 ease-in-out ${slideAnimation[position]} flex flex-col`}
         role="dialog"
         aria-modal="true"
         aria-labelledby={title ? 'sidebar-title' : undefined}


### PR DESCRIPTION
## Summary
- `Sidebar.tsx` (used by `BusinessDetailPanel.tsx`) now goes full-width below the `md` breakpoint (`w-full`) and only applies its fixed `sm`/`md`/`lg` widths (`w-80`/`w-96`/`w-[32rem]`) at `md:` and up, so it no longer overflows the mobile viewport.
- Width-only change; the existing slide/backdrop/escape-key behavior is unchanged.

Closes #199

## Test plan
- [x] `npm run lint`
- [x] `npm run build` (tsc -b && vite build)
- [ ] Sidebar (`BusinessDetailPanel`) goes full-width on mobile (`< md`, 768px)
- [ ] Sidebar keeps its `md:`+ fixed widths (`sm`/`md`/`lg`) on tablet and desktop
