### PR TITLE
Enable single-finger pan on the map

### DIFF
--- a/tipical-frontend/src/components/map/GoogleMap.tsx
+++ b/tipical-frontend/src/components/map/GoogleMap.tsx
@@ -256,6 +256,7 @@ export function GoogleMap({ businesses = [], isSearching = false, initialCenter,
         defaultCenter={initialCenter}
         defaultZoom={initialZoom}
         style={MAP_CONTAINER_STYLE}
+        gestureHandling="greedy"
         streetViewControl={false}
         mapTypeControl={false}
         fullscreenControl={false}


### PR DESCRIPTION
## Summary

The `<Map>` component in `GoogleMap.tsx` now passes `gestureHandling="greedy"`, so a single-finger drag pans the map on touch devices. Since the map is the only scrollable content on the page, there's no need to reserve one-finger gestures for page scrolling.

Closes #202
