### PR TITLE
Fix BusinessInfoWindow width and CTA clipping on mobile

### DIFF
--- a/tipical-frontend/src/components/map/BusinessInfoWindow.tsx
+++ b/tipical-frontend/src/components/map/BusinessInfoWindow.tsx
@@ -10,6 +10,36 @@ interface BusinessInfoWindowProps {
   business: Business;
 }
 
+interface CarouselNavButtonProps {
+  direction: 'prev' | 'next';
+  onClick: (e: React.MouseEvent) => void;
+}
+
+function CarouselNavButton({ direction, onClick }: CarouselNavButtonProps) {
+  const isPrev = direction === 'prev';
+  return (
+    <button
+      aria-label={isPrev ? 'Previous photo' : 'Next photo'}
+      onClick={onClick}
+      className={`absolute ${isPrev ? 'left-0' : 'right-0'} top-1/2 -translate-y-1/2 h-11 w-11 flex items-center justify-center`}
+    >
+      <span className="bg-black/40 text-white rounded-full w-5 h-5 text-xs flex items-center justify-center leading-none">
+        {isPrev ? '‹' : '›'}
+      </span>
+    </button>
+  );
+}
+
+// This card is rendered inside a Google Maps <InfoWindow>, whose own content wrapper has
+// `overflow: auto` — anything wider than that wrapper gets clipped (e.g. the CTA button).
+// Google computes the wrapper's actual rendered width from `maxWidth` (passed on the
+// <InfoWindow> in GoogleMap.tsx) combined with the map container's own size, and can render it
+// narrower than the `maxWidth` we ask for on a tight mobile map. Rather than hardcoding a card
+// width and hoping it matches whatever Google decides (it doesn't reliably, across devices),
+// the card below uses `w-full` so it always exactly fills whatever width Google's wrapper
+// actually ends up with — this constant only caps how wide that request is in the first place.
+export const INFO_WINDOW_MAX_WIDTH_PX = 260;
+
 export function BusinessInfoWindow({ business }: BusinessInfoWindowProps) {
   const openBusinessPanel = useUIStore(s => s.openBusinessPanel);
   const setShowAuthModal = useUIStore(s => s.setShowAuthModal);
@@ -58,20 +88,8 @@ export function BusinessInfoWindow({ business }: BusinessInfoWindowProps) {
           />
           {photos.length > 1 && (
             <>
-              <button
-                aria-label="Previous photo"
-                onClick={prevPhoto}
-                className="absolute left-1 top-1/2 -translate-y-1/2 bg-black/40 text-white rounded-full w-5 h-5 text-xs flex items-center justify-center leading-none"
-              >
-                ‹
-              </button>
-              <button
-                aria-label="Next photo"
-                onClick={nextPhoto}
-                className="absolute right-1 top-1/2 -translate-y-1/2 bg-black/40 text-white rounded-full w-5 h-5 text-xs flex items-center justify-center leading-none"
-              >
-                ›
-              </button>
+              <CarouselNavButton direction="prev" onClick={prevPhoto} />
+              <CarouselNavButton direction="next" onClick={nextPhoto} />
               <span className="absolute bottom-1 right-1 bg-black/40 text-white text-xs rounded px-1">
                 {photoIndex + 1}/{photos.length}
               </span>
@@ -88,7 +106,7 @@ export function BusinessInfoWindow({ business }: BusinessInfoWindowProps) {
   };
 
   return (
-    <div className="w-[260px]">
+    <div className="w-full">
       {renderPhotoArea()}
 
       <div className="p-2">

--- a/tipical-frontend/src/components/map/GoogleMap.tsx
+++ b/tipical-frontend/src/components/map/GoogleMap.tsx
@@ -5,7 +5,7 @@ import { useSearchStore } from '../../stores/searchStore';
 import { useGeolocation } from '../../hooks';
 import type { Business } from '../../types';
 import { BusinessMarker, INFO_WINDOW_OFFSET } from './BusinessMarker';
-import { BusinessInfoWindow } from './BusinessInfoWindow';
+import { BusinessInfoWindow, INFO_WINDOW_MAX_WIDTH_PX } from './BusinessInfoWindow';
 import { SearchThisAreaButton } from './SearchThisAreaButton';
 
 const MAP_CONTAINER_STYLE: React.CSSProperties = { width: '100%', height: '100%' };
@@ -130,6 +130,15 @@ const MapMarkers = memo(function MapMarkers({ businesses, activeMarkerId, disabl
     ? businesses.find(b => b.googlePlaceId === activeMarkerId) ?? null
     : null;
 
+  // Google computes its own default InfoWindow max width from the map container's size, which
+  // varies by device and can be narrower than a fixed-width content card, causing Google's
+  // `overflow: auto` content wrapper to clip anything that doesn't fit (including the CTA
+  // button). `maxWidth` here is just our ceiling ask — Google may still render the bubble
+  // narrower than this on a tight mobile map. The content card in BusinessInfoWindow.tsx uses
+  // `w-full` rather than a fixed px width specifically so it always exactly fills whatever box
+  // Google actually renders, instead of the two needing to independently compute the same
+  // pixel value (which doesn't hold across devices).
+
   return (
     <>
       {businesses.map(business => (
@@ -144,11 +153,12 @@ const MapMarkers = memo(function MapMarkers({ businesses, activeMarkerId, disabl
         <InfoWindow
           position={{ lat: activeBusiness.latitude, lng: activeBusiness.longitude }}
           pixelOffset={INFO_WINDOW_OFFSET}
+          maxWidth={INFO_WINDOW_MAX_WIDTH_PX}
           onCloseClick={onInfoWindowClose}
           disableAutoPan={disableAutoPan || undefined}
           zIndex={50}
         >
-          <BusinessInfoWindow business={activeBusiness} />
+          <BusinessInfoWindow key={activeBusiness.googlePlaceId} business={activeBusiness} />
         </InfoWindow>
       )}
     </>


### PR DESCRIPTION
## Summary

`BusinessInfoWindow` and the `<InfoWindow>` that hosts it (`MapMarkers` in `GoogleMap.tsx`) are fixed to no longer clip content on mobile.

- **Card sizing**: the card is `w-full` instead of a fixed pixel width, so it always exactly fills whatever width Google's `InfoWindow` content wrapper actually renders. Google computes that wrapper's width from the `maxWidth` passed on `<InfoWindow>` combined with the map container's own size, and can render it narrower than the requested `maxWidth` on a tight mobile map — a fixed-width card doesn't follow that discrepancy and gets clipped. `<InfoWindow maxWidth={INFO_WINDOW_MAX_WIDTH_PX}>` (260px) is just a ceiling on the request; the card's `w-full` sizing means it can never exceed whatever Google actually renders, on any device. The carousel's prev/next photo buttons also now have a ~44px hit area (via padding, with the visible icon unchanged) to meet the 44px touch-target guideline.
- **Stale carousel state**: `BusinessInfoWindow` is now `key`ed by `business.googlePlaceId` in `GoogleMap.tsx`, so React remounts it (resetting local `photoIndex` state) when the active business changes, instead of reusing the instance and carrying a stale photo index into a business with fewer photos (which rendered a broken image).
- **Cleanup**: extracted the duplicated prev/next carousel button JSX into a `CarouselNavButton` subcomponent.

## Files changed

- `tipical-frontend/src/components/map/BusinessInfoWindow.tsx` — `w-full` card, carousel arrow hit areas, `CarouselNavButton` extraction
- `tipical-frontend/src/components/map/GoogleMap.tsx` (`MapMarkers`) — explicit `maxWidth` on `<InfoWindow>`, `key`ed `BusinessInfoWindow`

## Test plan

- [x] `npm run lint` passes
- [x] `npm run build` (`tsc -b && vite build`) passes
- [x] Manually verified on narrow and desktop-width viewports that the InfoWindow card fits without a horizontal scrollbar and the CTA button is fully visible
- [x] Manually verified switching between businesses with different photo counts no longer shows a broken image

Closes #203
