### PR TITLE
Fix Google Maps deep link URL format for iOS/Android app handoff

### DIFF
--- a/tipical-frontend/src/components/business/BusinessDetailPanel.tsx
+++ b/tipical-frontend/src/components/business/BusinessDetailPanel.tsx
@@ -21,7 +21,11 @@ export function BusinessDetailPanel({ business }: BusinessDetailPanelProps) {
   const { data: detail, isLoading: detailLoading } = useBusinessDetail(business.googlePlaceId, { enabled: showBusinessPanel });
 
   const photos = detail?.photos ?? [];
-  const mapsUrl = `https://www.google.com/maps/place/?q=place_id:${business.googlePlaceId}`;
+  // Google's documented "universal URL" format (maps/search/?api=1&query=...&query_place_id=...)
+  // is guaranteed to auto-launch the native Google Maps app on iOS/Android when installed, with
+  // a plain link -- no custom scheme or JS navigation workaround needed. See:
+  // https://developers.google.com/maps/documentation/urls/get-started#search-examples
+  const mapsUrl = `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(business.name)}&query_place_id=${business.googlePlaceId}`;
 
   const mapsLink = (
     <a


### PR DESCRIPTION
## Summary

The "Open in Google Maps" link on the business detail panel (`tipical-frontend/src/components/business/BusinessDetailPanel.tsx`) now uses Google's documented "universal URL" format, so it correctly deep-links into the native Google Maps app on iOS (and Android) when installed.

The link previously used the older query format:
```
https://www.google.com/maps/place/?q=place_id:<googlePlaceId>
```
This format isn't reliably registered for iOS's Universal Link app-association, so the link opened the Google Maps web page in Safari instead of handing off to the native app.

Google's docs explicitly document a different format as the "universal URL" for deep-linking to a specific place, guaranteed to auto-launch the native app on both iOS and Android when installed — with a plain link, no custom URL scheme, and no JS navigation workaround required:
```
https://www.google.com/maps/search/?api=1&query=<place name>&query_place_id=<place id>
```
(See [Example 5](https://developers.google.com/maps/documentation/urls/get-started#search-examples) in Google's Maps URLs docs.)

This is a one-line fix to the `mapsUrl` construction — the anchor itself is unchanged (`target="_blank"` `rel="noopener noreferrer"`, opens in a new tab, same as before for users without the app installed).

## Verification

- `pnpm lint` and `pnpm build` (which runs `tsc -b`) both pass.
- **On-device iOS verification is still needed.** I don't have access to a physical iOS/Android device to confirm this URL format actually triggers the app handoff in practice. Please test on a real device (with and without the Google Maps app installed) before considering this fully verified — see the test plan in #209.

Closes #209
