### PR TITLE
Add structured logging with Serilog and Google Cloud Logging sink

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -104,13 +104,15 @@ jobs:
 
       - name: Deploy to Cloud Run
         id: deploy
+        env:
+          IMAGE_TAG: ${{ inputs.image_tag }}
         run: |
           gcloud run deploy tipical-api-prod \
             --image ${{ needs.validate-tag.outputs.image }} \
             --region ${{ env.REGION }} \
             --add-cloudsql-instances ${{ vars.GCP_PROJECT_ID }}:${{ env.REGION }}:tipical-db-prod \
             --set-secrets "ConnectionStrings__DefaultConnection=prod-db-connection-string:latest,GooglePlaces__ApiKey=prod-google-places-api-key:latest,GoogleOAuth__ClientId=prod-google-oauth-client-id:latest,JwtSettings__Secret=prod-jwt-secret:latest" \
-            --set-env-vars "^|^ASPNETCORE_ENVIRONMENT=Production|Cors__AllowedOrigins__0=https://tipscape.app|AllowedUsers__Enabled=${{ vars.ALLOWED_USERS_ENABLED }}" \
+            --set-env-vars "^|^ASPNETCORE_ENVIRONMENT=Production|Cors__AllowedOrigins__0=https://tipscape.app|AllowedUsers__Enabled=${{ vars.ALLOWED_USERS_ENABLED }}|Serilog__WriteTo__0__Name=GoogleCloudLogging|Serilog__WriteTo__0__Args__projectId=${{ vars.GCP_PROJECT_ID }}|Serilog__WriteTo__0__Args__serviceName=tipical-api-prod|Serilog__WriteTo__0__Args__serviceVersion=${IMAGE_TAG}" \
             --service-account tipical-api-prod@${{ vars.GCP_PROJECT_ID }}.iam.gserviceaccount.com \
             --allow-unauthenticated \
             --quiet

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -106,7 +106,7 @@ jobs:
             --region ${{ env.REGION }} \
             --add-cloudsql-instances ${{ vars.GCP_PROJECT_ID }}:${{ env.REGION }}:tipical-db-test \
             --set-secrets "ConnectionStrings__DefaultConnection=test-db-connection-string:latest,GooglePlaces__ApiKey=test-google-places-api-key:latest,GoogleOAuth__ClientId=test-google-oauth-client-id:latest,JwtSettings__Secret=test-jwt-secret:latest" \
-            --set-env-vars "^|^ASPNETCORE_ENVIRONMENT=Production|Cors__AllowedOrigins__0=https://tipical-test.web.app|AllowedUsers__Enabled=${{ vars.ALLOWED_USERS_ENABLED }}" \
+            --set-env-vars "^|^ASPNETCORE_ENVIRONMENT=Production|Cors__AllowedOrigins__0=https://tipical-test.web.app|AllowedUsers__Enabled=${{ vars.ALLOWED_USERS_ENABLED }}|Serilog__WriteTo__0__Name=GoogleCloudLogging|Serilog__WriteTo__0__Args__projectId=${{ vars.GCP_PROJECT_ID }}|Serilog__WriteTo__0__Args__serviceName=tipical-api-test|Serilog__WriteTo__0__Args__serviceVersion=${{ github.sha }}" \
             --service-account tipical-api-test@${{ vars.GCP_PROJECT_ID }}.iam.gserviceaccount.com \
             --allow-unauthenticated \
             --quiet

--- a/tipical-backend/Directory.Packages.props
+++ b/tipical-backend/Directory.Packages.props
@@ -17,6 +17,11 @@
     <PackageVersion Include="NetTopologySuite" Version="2.6.0" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="10.0.2" />
+    <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
+    <PackageVersion Include="Serilog.Enrichers.Environment" Version="3.0.1" />
+    <PackageVersion Include="Serilog.Enrichers.Thread" Version="4.0.0" />
+    <PackageVersion Include="Serilog.Exceptions" Version="8.4.0" />
+    <PackageVersion Include="Serilog.Sinks.GoogleCloudLogging" Version="5.0.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.3" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
     <PackageVersion Include="TUnit" Version="1.56.35" />

--- a/tipical-backend/src/Tipical.Api/Program.cs
+++ b/tipical-backend/src/Tipical.Api/Program.cs
@@ -4,6 +4,7 @@ using Tipical.Api;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi;
+using Serilog;
 using System.Reflection;
 using System.Text;
 using System.Threading.RateLimiting;
@@ -14,7 +15,25 @@ using Tipical.Infrastructure.Data;
 using Tipical.Infrastructure.Repositories;
 using Tipical.Infrastructure.Services;
 
+// Bootstrap logger: captures anything logged before the host (and its
+// configuration-driven Serilog setup) is built. Replaced by the configured
+// logger once the host is up.
+Log.Logger = new LoggerConfiguration()
+    .WriteTo.Console()
+    .CreateBootstrapLogger();
+
+try
+{
+    Log.Information("Starting Tipical API");
+
 var builder = WebApplication.CreateBuilder(args);
+
+// Configure Serilog from appsettings (Console locally, Google Cloud Logging in
+// the deployed Production environment). ReadFrom.Services lets registered
+// enrichers/sinks participate in the pipeline.
+builder.Services.AddSerilog((services, loggerConfiguration) => loggerConfiguration
+    .ReadFrom.Configuration(builder.Configuration)
+    .ReadFrom.Services(services));
 
 // Add services to the container
 builder.Services.AddControllers()
@@ -131,6 +150,10 @@ if (app.Environment.IsDevelopment())
     app.UseSwaggerUI();
 }
 
+// Emit a single structured log entry per HTTP request (method, path, status,
+// elapsed time) instead of the framework's noisy multi-line default.
+app.UseSerilogRequestLogging();
+
 // Global exception handling
 app.UseExceptionHandler(errorApp =>
 {
@@ -149,4 +172,16 @@ app.UseAuthentication();
 app.UseAuthorization();
 app.MapControllers();
 
-app.Run();
+    app.Run();
+}
+// HostAbortedException is thrown intentionally by EF Core design-time tools
+// (e.g. `dotnet ef migrations`/`database update`) to stop before app.Run();
+// it isn't a real failure, so don't log it as fatal.
+catch (Exception ex) when (ex is not HostAbortedException)
+{
+    Log.Fatal(ex, "Tipical API terminated unexpectedly");
+}
+finally
+{
+    Log.CloseAndFlush();
+}

--- a/tipical-backend/src/Tipical.Api/Tipical.Api.csproj
+++ b/tipical-backend/src/Tipical.Api/Tipical.Api.csproj
@@ -18,6 +18,11 @@
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
     <PackageReference Include="Microsoft.OpenApi" />
+    <PackageReference Include="Serilog.AspNetCore" />
+    <PackageReference Include="Serilog.Enrichers.Environment" />
+    <PackageReference Include="Serilog.Enrichers.Thread" />
+    <PackageReference Include="Serilog.Exceptions" />
+    <PackageReference Include="Serilog.Sinks.GoogleCloudLogging" />
     <PackageReference Include="Swashbuckle.AspNetCore" />
   </ItemGroup>
 

--- a/tipical-backend/src/Tipical.Api/appsettings.json
+++ b/tipical-backend/src/Tipical.Api/appsettings.json
@@ -1,9 +1,27 @@
 {
-  "Logging": {
-    "LogLevel": {
+  "Serilog": {
+    "Using": [
+      "Serilog.Sinks.Console",
+      "Serilog.Sinks.GoogleCloudLogging",
+      "Serilog.Enrichers.Environment",
+      "Serilog.Enrichers.Thread",
+      "Serilog.Exceptions"
+    ],
+    "MinimumLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
+      "Override": {
+        "Microsoft": "Warning",
+        "Microsoft.AspNetCore.Hosting.Diagnostics": "Error",
+        "Microsoft.Hosting.Lifetime": "Information",
+        "Microsoft.EntityFrameworkCore.Database.Command": "Warning",
+        "System.Net.Http.HttpClient": "Warning"
+      }
+    },
+    "Enrich": [ "FromLogContext", "WithMachineName", "WithThreadId", "WithExceptionDetails" ],
+    "//WriteTo": "Console is the safe default for local dev. Deployed environments (test/prod on Cloud Run) override WriteTo[0] to the GoogleCloudLogging sink via Serilog__WriteTo__0__* environment variables set in the deploy workflows.",
+    "WriteTo": [
+      { "Name": "Console" }
+    ]
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {


### PR DESCRIPTION
Closes #213.

Sets up structured logging in the .NET backend with [Serilog](https://codewithmukesh.com/blog/structured-logging-with-serilog-in-aspnet-core/): logs go to the console during local development and to **Google Cloud Logging** (via `Serilog.Sinks.GoogleCloudLogging`) in the deployed **test** and **prod** environments.

## What this does

- Adds Serilog to `Tipical.Api`: `Serilog.AspNetCore`, `Serilog.Sinks.GoogleCloudLogging`, and the `Environment`, `Thread`, and `Exceptions` enrichers.
- Wires Serilog in `Program.cs`: a bootstrap logger, `AddSerilog(...ReadFrom.Configuration().ReadFrom.Services())`, `UseSerilogRequestLogging()` (one structured entry per HTTP request), and a `try/catch/finally` around startup so fatal errors are logged and flushed.
- Replaces the `Logging` section in `appsettings.json` with a `Serilog` section: minimum-level overrides, `FromLogContext`/`WithMachineName`/`WithThreadId`/`WithExceptionDetails` enrichers, and a **Console** sink as the safe default (local dev and any environment without an override).

## How the GCP sink is selected

Both the test and prod Cloud Run services run with `ASPNETCORE_ENVIRONMENT=Production`, and this repo keeps `appsettings.{Environment}.json` gitignored — deployed configuration is injected via Cloud Run env vars/secrets, not shipped in the image. So the GCP sink is enabled in `deploy-test.yml` and `deploy-prod.yml` by overriding the tracked Console default:

```
Serilog__WriteTo__0__Name=GoogleCloudLogging
Serilog__WriteTo__0__Args__projectId=${{ vars.GCP_PROJECT_ID }}
Serilog__WriteTo__0__Args__serviceName=tipical-api-{test|prod}
Serilog__WriteTo__0__Args__serviceVersion=<image tag / commit SHA>
```

- `projectId` is passed explicitly rather than relying on GCP metadata auto-detection, which does not reliably identify the project on Cloud Run (the sink constructs eagerly and would otherwise fail at startup).
- `serviceName`/`serviceVersion` emit the `serviceContext` that **Cloud Error Reporting** requires, so logged exceptions group in Error Reporting — separately per environment, and tagged with the deployed version.

The sink translates Serilog levels to GCP `LogSeverity` (Information→Info, Warning→Warning, Error→Error, Fatal→Critical), so severity, filtering, and log-based metrics behave correctly in the Logs Explorer.

## Prerequisite (already applied)

The Cloud Run service accounts (`tipical-api-test@…`, `tipical-api-prod@…`) need `roles/logging.logWriter` for log entries to be written; this has been granted on project `tipical`.

## Testing

- `dotnet build` on the full solution; all 14 tests pass.
- Ran locally in `Development` → console output confirmed.
- Simulated the deployed config (tracked `appsettings.json` + the workflow env vars) → the GoogleCloudLogging sink resolves and only fails on Application Default Credentials locally, which are supplied by the service account on Cloud Run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
