### PR TITLE
Add Firebase Hosting rewrites to proxy /api to Cloud Run

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -10,6 +10,13 @@
       ],
       "rewrites": [
         {
+          "source": "/api/**",
+          "run": {
+            "serviceId": "tipical-api-test",
+            "region": "us-central1"
+          }
+        },
+        {
           "source": "**",
           "destination": "/index.html"
         }
@@ -44,6 +51,13 @@
         "**/node_modules/**"
       ],
       "rewrites": [
+        {
+          "source": "/api/**",
+          "run": {
+            "serviceId": "tipical-api-prod",
+            "region": "us-central1"
+          }
+        },
         {
           "source": "**",
           "destination": "/index.html"


### PR DESCRIPTION
## Summary

Adds a Firebase Hosting rewrite in each hosting target (`tipical`, `tipical-test`) so `/api/**` is proxied straight to the corresponding Cloud Run service (`tipical-api-prod` / `tipical-api-test`, `us-central1`) instead of the frontend calling Cloud Run cross-origin. Both Cloud Run services already run with `--allow-unauthenticated`, which is what Firebase Hosting's Cloud Run rewrite requires.

This is part of #215, not the whole fix — see follow-up below.

## Follow-up required (not done in this PR)

For this to actually take effect, `VITE_API_BASE_URL` needs to change from the absolute Cloud Run URL to a relative path (`/api/v1`) in the GitHub `test` and `prod` environment variables — this is live deployment config, not something in the repo, so I didn't flip it as part of this diff. Suggested rollout:

1. Merge this PR — `deploy-test.yml` will redeploy the `tipical-test` Firebase Hosting target with the new rewrite in place. Existing behavior is unaffected since `VITE_API_BASE_URL` still points at the absolute Cloud Run URL.
2. Update the `test` environment's `VITE_API_BASE_URL` to `/api/v1`, push a no-op/trivial change (or re-run the workflow) to redeploy the frontend, and verify requests go through same-origin with no OPTIONS preflight in the logs.
3. Once verified on test, update the `prod` environment's `VITE_API_BASE_URL` to `/api/v1` and run the prod deploy workflow.

## Notes

- Backend CORS config (`Program.cs`, `appsettings.json`) is left as-is — local dev still calls the API cross-origin (frontend on `:5173`/`:3000`, API on `:5000`), so it's still needed there. It becomes a no-op for same-origin browser traffic in test/prod once step 2/3 above land.
- Cloud Run smoke tests in the deploy workflows curl the Cloud Run URL directly (server-to-server), so they're unaffected by this change.

Part of #215
