### PR TITLE
Remove unused CORS origin override from deploy workflows

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -112,7 +112,7 @@ jobs:
             --region ${{ env.REGION }} \
             --add-cloudsql-instances ${{ vars.GCP_PROJECT_ID }}:${{ env.REGION }}:tipical-db-prod \
             --set-secrets "ConnectionStrings__DefaultConnection=prod-db-connection-string:latest,GooglePlaces__ApiKey=prod-google-places-api-key:latest,GoogleOAuth__ClientId=prod-google-oauth-client-id:latest,JwtSettings__Secret=prod-jwt-secret:latest" \
-            --set-env-vars "^|^ASPNETCORE_ENVIRONMENT=Production|Cors__AllowedOrigins__0=https://tipscape.app|AllowedUsers__Enabled=${{ vars.ALLOWED_USERS_ENABLED }}|Serilog__WriteTo__0__Name=GoogleCloudLogging|Serilog__WriteTo__0__Args__projectId=${{ vars.GCP_PROJECT_ID }}|Serilog__WriteTo__0__Args__serviceName=tipical-api-prod|Serilog__WriteTo__0__Args__serviceVersion=${IMAGE_TAG}" \
+            --set-env-vars "^|^ASPNETCORE_ENVIRONMENT=Production|AllowedUsers__Enabled=${{ vars.ALLOWED_USERS_ENABLED }}|Serilog__WriteTo__0__Name=GoogleCloudLogging|Serilog__WriteTo__0__Args__projectId=${{ vars.GCP_PROJECT_ID }}|Serilog__WriteTo__0__Args__serviceName=tipical-api-prod|Serilog__WriteTo__0__Args__serviceVersion=${IMAGE_TAG}" \
             --service-account tipical-api-prod@${{ vars.GCP_PROJECT_ID }}.iam.gserviceaccount.com \
             --allow-unauthenticated \
             --quiet
@@ -148,7 +148,6 @@ jobs:
         run: pnpm run build
         working-directory: tipical-frontend
         env:
-          VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL }}
           VITE_GOOGLE_MAPS_API_KEY: ${{ vars.VITE_GOOGLE_MAPS_API_KEY }}
           VITE_GOOGLE_MAPS_MAP_ID: ${{ vars.VITE_GOOGLE_MAPS_MAP_ID }}
           VITE_GOOGLE_OAUTH_CLIENT_ID: ${{ vars.VITE_GOOGLE_OAUTH_CLIENT_ID }}

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -106,7 +106,7 @@ jobs:
             --region ${{ env.REGION }} \
             --add-cloudsql-instances ${{ vars.GCP_PROJECT_ID }}:${{ env.REGION }}:tipical-db-test \
             --set-secrets "ConnectionStrings__DefaultConnection=test-db-connection-string:latest,GooglePlaces__ApiKey=test-google-places-api-key:latest,GoogleOAuth__ClientId=test-google-oauth-client-id:latest,JwtSettings__Secret=test-jwt-secret:latest" \
-            --set-env-vars "^|^ASPNETCORE_ENVIRONMENT=Production|Cors__AllowedOrigins__0=https://tipical-test.web.app|AllowedUsers__Enabled=${{ vars.ALLOWED_USERS_ENABLED }}|Serilog__WriteTo__0__Name=GoogleCloudLogging|Serilog__WriteTo__0__Args__projectId=${{ vars.GCP_PROJECT_ID }}|Serilog__WriteTo__0__Args__serviceName=tipical-api-test|Serilog__WriteTo__0__Args__serviceVersion=${{ github.sha }}" \
+            --set-env-vars "^|^ASPNETCORE_ENVIRONMENT=Production|AllowedUsers__Enabled=${{ vars.ALLOWED_USERS_ENABLED }}|Serilog__WriteTo__0__Name=GoogleCloudLogging|Serilog__WriteTo__0__Args__projectId=${{ vars.GCP_PROJECT_ID }}|Serilog__WriteTo__0__Args__serviceName=tipical-api-test|Serilog__WriteTo__0__Args__serviceVersion=${{ github.sha }}" \
             --service-account tipical-api-test@${{ vars.GCP_PROJECT_ID }}.iam.gserviceaccount.com \
             --allow-unauthenticated \
             --quiet
@@ -140,7 +140,6 @@ jobs:
         run: pnpm run build
         working-directory: tipical-frontend
         env:
-          VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL }}
           VITE_GOOGLE_MAPS_API_KEY: ${{ vars.VITE_GOOGLE_MAPS_API_KEY }}
           VITE_GOOGLE_MAPS_MAP_ID: ${{ vars.VITE_GOOGLE_MAPS_MAP_ID }}
           VITE_GOOGLE_OAUTH_CLIENT_ID: ${{ vars.VITE_GOOGLE_OAUTH_CLIENT_ID }}

--- a/tipical-frontend/src/services/api.ts
+++ b/tipical-frontend/src/services/api.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { QueryClient } from '@tanstack/react-query';
 import { useAuthStore } from '../stores/authStore';
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000/api/v1';
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api/v1';
 
 export const apiClient = axios.create({
   baseURL: API_BASE_URL,


### PR DESCRIPTION
## Summary

Cleanup now that the frontend and API are same-origin in test/prod (#216), verified via Cloud Logging (no more `OPTIONS` preflight to `tipical-api-test` or `tipical-api-prod`):

- Removes the `Cors__AllowedOrigins__0` override from the `test`/`prod` Cloud Run deploy commands. Deployed environments now fall back to the `Cors:AllowedOrigins` default in `appsettings.json` (`localhost:5173`/`localhost:3000`), which only matters for local dev where the frontend (`:5173`/`:3000`) and API (`:5000`) are still on different ports.
- Drops `VITE_API_BASE_URL` as a build variable and hardcodes `/api/v1` as the fallback in `api.ts`. It resolved to the identical value in both `test` and `prod` once both went through the Firebase Hosting proxy, so there was nothing left for the variable to vary. Local dev is unaffected — it still overrides via its own `.env` file per `.env.example`.

Closes #215
