### PR TITLE
Deny CORS by default, allow localhost only via local dev override

### DIFF
--- a/tipical-backend/src/Tipical.Api/Program.cs
+++ b/tipical-backend/src/Tipical.Api/Program.cs
@@ -117,7 +117,7 @@ builder.Services.AddRateLimiter(options =>
 builder.Services.Configure<AllowedUsersOptions>(builder.Configuration.GetSection("AllowedUsers"));
 
 // Configure CORS
-var allowedOrigins = builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>()!;
+var allowedOrigins = builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>() ?? [];
 builder.Services.AddCors(options =>
 {
     options.AddDefaultPolicy(policy =>

--- a/tipical-backend/src/Tipical.Api/appsettings.json
+++ b/tipical-backend/src/Tipical.Api/appsettings.json
@@ -39,9 +39,6 @@
     "Audience": "TipicalApp",
     "ExpirationHours": 24
   },
-  "Cors": {
-    "AllowedOrigins": ["http://localhost:5173", "http://localhost:3000"]
-  },
   "AllowedUsers": {
     "Enabled": false
   }


### PR DESCRIPTION
## Summary

Follow-up to #216/#217: `Cors:AllowedOrigins` in `appsettings.json` defaulted to `["http://localhost:5173", "http://localhost:3000"]`, and since #217 removed the test/prod `Cors__AllowedOrigins__0` override, deployed environments were silently inheriting that default — allowing `localhost` origins to make cross-origin requests against the live API.

Removes the `Cors` section from `appsettings.json` entirely and makes `Program.cs` null-safe for it (`.Get<string[]>() ?? []` instead of the null-forgiving `!`), so an environment with no `Cors` config denies cross-origin requests by default instead of allowing localhost or crashing on startup.

Local dev is unaffected: `docker-compose.yml` already sets `Cors__AllowedOrigins__0=http://localhost:5173` as an explicit override, independent of any `appsettings.json` default. `:3000` wasn't referenced anywhere in the frontend tooling (Vite defaults to `5173`), so it was dead config.

## Verification

Ran `docker compose up -d postgres api --build` locally with this change:
- App starts cleanly with no `Cors` section present.
- `OPTIONS` preflight from `Origin: http://localhost:5173` returns `Access-Control-Allow-Origin: http://localhost:5173`.
- `OPTIONS` preflight from an arbitrary origin returns no `Access-Control-Allow-Origin` header (correctly rejected).

Closes #215
