### PR TITLE
Add distributed tracing with OpenTelemetry

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -112,7 +112,7 @@ jobs:
             --region ${{ env.REGION }} \
             --add-cloudsql-instances ${{ vars.GCP_PROJECT_ID }}:${{ env.REGION }}:tipical-db-prod \
             --set-secrets "ConnectionStrings__DefaultConnection=prod-db-connection-string:latest,GooglePlaces__ApiKey=prod-google-places-api-key:latest,GoogleOAuth__ClientId=prod-google-oauth-client-id:latest,JwtSettings__Secret=prod-jwt-secret:latest" \
-            --set-env-vars "^|^ASPNETCORE_ENVIRONMENT=Production|AllowedUsers__Enabled=${{ vars.ALLOWED_USERS_ENABLED }}|Serilog__WriteTo__0__Name=GoogleCloudLogging|Serilog__WriteTo__0__Args__projectId=${{ vars.GCP_PROJECT_ID }}|Serilog__WriteTo__0__Args__serviceName=tipical-api-prod|Serilog__WriteTo__0__Args__serviceVersion=${IMAGE_TAG}" \
+            --set-env-vars "^|^ASPNETCORE_ENVIRONMENT=Production|AllowedUsers__Enabled=${{ vars.ALLOWED_USERS_ENABLED }}|Serilog__WriteTo__0__Name=GoogleCloudLogging|Serilog__WriteTo__0__Args__projectId=${{ vars.GCP_PROJECT_ID }}|Serilog__WriteTo__0__Args__serviceName=tipical-api-prod|Serilog__WriteTo__0__Args__serviceVersion=${IMAGE_TAG}|OpenTelemetry__ServiceName=tipical-api-prod|OpenTelemetry__ServiceVersion=${IMAGE_TAG}|OpenTelemetry__Otlp__Endpoint=https://telemetry.googleapis.com/v1/traces" \
             --service-account tipical-api-prod@${{ vars.GCP_PROJECT_ID }}.iam.gserviceaccount.com \
             --allow-unauthenticated \
             --quiet

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -106,7 +106,7 @@ jobs:
             --region ${{ env.REGION }} \
             --add-cloudsql-instances ${{ vars.GCP_PROJECT_ID }}:${{ env.REGION }}:tipical-db-test \
             --set-secrets "ConnectionStrings__DefaultConnection=test-db-connection-string:latest,GooglePlaces__ApiKey=test-google-places-api-key:latest,GoogleOAuth__ClientId=test-google-oauth-client-id:latest,JwtSettings__Secret=test-jwt-secret:latest" \
-            --set-env-vars "^|^ASPNETCORE_ENVIRONMENT=Production|AllowedUsers__Enabled=${{ vars.ALLOWED_USERS_ENABLED }}|Serilog__WriteTo__0__Name=GoogleCloudLogging|Serilog__WriteTo__0__Args__projectId=${{ vars.GCP_PROJECT_ID }}|Serilog__WriteTo__0__Args__serviceName=tipical-api-test|Serilog__WriteTo__0__Args__serviceVersion=${{ github.sha }}" \
+            --set-env-vars "^|^ASPNETCORE_ENVIRONMENT=Production|AllowedUsers__Enabled=${{ vars.ALLOWED_USERS_ENABLED }}|Serilog__WriteTo__0__Name=GoogleCloudLogging|Serilog__WriteTo__0__Args__projectId=${{ vars.GCP_PROJECT_ID }}|Serilog__WriteTo__0__Args__serviceName=tipical-api-test|Serilog__WriteTo__0__Args__serviceVersion=${{ github.sha }}|OpenTelemetry__ServiceName=tipical-api-test|OpenTelemetry__ServiceVersion=${{ github.sha }}|OpenTelemetry__Otlp__Endpoint=https://telemetry.googleapis.com/v1/traces" \
             --service-account tipical-api-test@${{ vars.GCP_PROJECT_ID }}.iam.gserviceaccount.com \
             --allow-unauthenticated \
             --quiet

--- a/tipical-backend/Directory.Packages.props
+++ b/tipical-backend/Directory.Packages.props
@@ -17,8 +17,15 @@
     <PackageVersion Include="NetTopologySuite" Version="2.6.0" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="10.0.2" />
+    <PackageVersion Include="Npgsql.OpenTelemetry" Version="10.0.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageVersion Include="Serilog.Enrichers.Environment" Version="3.0.1" />
+    <PackageVersion Include="Serilog.Enrichers.Span" Version="3.1.0" />
     <PackageVersion Include="Serilog.Enrichers.Thread" Version="4.0.0" />
     <PackageVersion Include="Serilog.Exceptions" Version="8.4.0" />
     <PackageVersion Include="Serilog.Sinks.GoogleCloudLogging" Version="5.0.0" />

--- a/tipical-backend/src/Tipical.Api/GoogleCloudTraceHttpClient.cs
+++ b/tipical-backend/src/Tipical.Api/GoogleCloudTraceHttpClient.cs
@@ -1,0 +1,31 @@
+using System.Net.Http.Headers;
+using Google.Apis.Auth.OAuth2;
+
+namespace Tipical.Api;
+
+// Cloud Trace's OTLP endpoint (telemetry.googleapis.com) is an authenticated Google
+// API, unlike a typical OTLP collector. This attaches a bearer token from the Cloud
+// Run service's Application Default Credentials to every export request. The token
+// is re-requested per call rather than cached here because GoogleCredential already
+// caches it internally and only refreshes once it's near expiry.
+internal static class GoogleCloudTraceHttpClient
+{
+    private static readonly string[] Scopes = ["https://www.googleapis.com/auth/trace.append"];
+
+    private static readonly Lazy<Task<GoogleCredential>> Credential = new(async () =>
+        (await GoogleCredential.GetApplicationDefaultAsync()).CreateScoped(Scopes));
+
+    public static HttpClient Create() => new(new AuthenticatingHandler());
+
+    private sealed class AuthenticatingHandler() : DelegatingHandler(new HttpClientHandler())
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var credential = await Credential.Value;
+            var token = await ((ITokenAccess)credential).GetAccessTokenForRequestAsync(cancellationToken: cancellationToken);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            return await base.SendAsync(request, cancellationToken);
+        }
+    }
+}

--- a/tipical-backend/src/Tipical.Api/Program.cs
+++ b/tipical-backend/src/Tipical.Api/Program.cs
@@ -4,6 +4,10 @@ using Tipical.Api;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi;
+using Npgsql;
+using OpenTelemetry.Exporter;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
 using Serilog;
 using System.Reflection;
 using System.Text;
@@ -34,6 +38,34 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddSerilog((services, loggerConfiguration) => loggerConfiguration
     .ReadFrom.Configuration(builder.Configuration)
     .ReadFrom.Services(services));
+
+// Configure OpenTelemetry tracing: console exporter locally, OTLP to Cloud Trace in
+// the deployed Production environment (see OpenTelemetry:Otlp:Endpoint in appsettings).
+var otlpEndpoint = builder.Configuration["OpenTelemetry:Otlp:Endpoint"];
+builder.Services.AddOpenTelemetry()
+    .ConfigureResource(resource => resource.AddService(
+        serviceName: builder.Configuration["OpenTelemetry:ServiceName"] ?? "tipical-api",
+        serviceVersion: builder.Configuration["OpenTelemetry:ServiceVersion"]))
+    .WithTracing(tracing =>
+    {
+        tracing.AddAspNetCoreInstrumentation()
+            .AddHttpClientInstrumentation()
+            .AddNpgsql();
+
+        if (string.IsNullOrEmpty(otlpEndpoint))
+        {
+            tracing.AddConsoleExporter();
+        }
+        else
+        {
+            tracing.AddOtlpExporter(otlp =>
+            {
+                otlp.Protocol = OtlpExportProtocol.HttpProtobuf;
+                otlp.Endpoint = new Uri(otlpEndpoint);
+                otlp.HttpClientFactory = GoogleCloudTraceHttpClient.Create;
+            });
+        }
+    });
 
 // Add services to the container
 builder.Services.AddControllers()

--- a/tipical-backend/src/Tipical.Api/Tipical.Api.csproj
+++ b/tipical-backend/src/Tipical.Api/Tipical.Api.csproj
@@ -18,8 +18,15 @@
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
     <PackageReference Include="Microsoft.OpenApi" />
+    <PackageReference Include="Npgsql.OpenTelemetry" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
     <PackageReference Include="Serilog.AspNetCore" />
     <PackageReference Include="Serilog.Enrichers.Environment" />
+    <PackageReference Include="Serilog.Enrichers.Span" />
     <PackageReference Include="Serilog.Enrichers.Thread" />
     <PackageReference Include="Serilog.Exceptions" />
     <PackageReference Include="Serilog.Sinks.GoogleCloudLogging" />

--- a/tipical-backend/src/Tipical.Api/appsettings.json
+++ b/tipical-backend/src/Tipical.Api/appsettings.json
@@ -4,6 +4,7 @@
       "Serilog.Sinks.Console",
       "Serilog.Sinks.GoogleCloudLogging",
       "Serilog.Enrichers.Environment",
+      "Serilog.Enrichers.Span",
       "Serilog.Enrichers.Thread",
       "Serilog.Exceptions"
     ],
@@ -17,7 +18,7 @@
         "System.Net.Http.HttpClient": "Warning"
       }
     },
-    "Enrich": [ "FromLogContext", "WithMachineName", "WithThreadId", "WithExceptionDetails" ],
+    "Enrich": [ "FromLogContext", "WithMachineName", "WithThreadId", "WithExceptionDetails", "WithSpan" ],
     "//WriteTo": "Console is the safe default for local dev. Deployed environments (test/prod on Cloud Run) override WriteTo[0] to the GoogleCloudLogging sink via Serilog__WriteTo__0__* environment variables set in the deploy workflows.",
     "WriteTo": [
       { "Name": "Console" }


### PR DESCRIPTION
## Summary

- Wires up OpenTelemetry tracing in the API (`Program.cs`): ASP.NET Core, `HttpClient`, and Npgsql instrumentation, exported to the console locally, or to Cloud Trace's OTLP endpoint (`telemetry.googleapis.com`) in deployed environments.
- Since Cloud Trace's OTLP endpoint is an authenticated Google API (unlike a typical OTLP collector), adds `GoogleCloudTraceHttpClient` — a small `DelegatingHandler` that attaches a bearer token from the Cloud Run service account's Application Default Credentials to every export request.
- Adds `Serilog.Enrichers.Span` so every log line carries the active `TraceId`/`SpanId`, letting logs (Google Cloud Logging) and traces (Cloud Trace) be correlated.
- Deploy workflows set `OpenTelemetry__ServiceName`, `OpenTelemetry__ServiceVersion`, and `OpenTelemetry__Otlp__Endpoint` env vars on Cloud Run, mirroring the existing `Serilog__WriteTo__0__*` pattern.
- Granted `roles/telemetry.tracesWriter` to the `tipical-api-test@...` and `tipical-api-prod@...` service accounts on the `tipical` GCP project, so no manual IAM step remains before this works after merge.

Closes #219.

## Test plan

- [x] `dotnet build` succeeds.
- [x] Ran the stack locally via `docker compose up` and hit `/api/v1/businesses/search`; confirmed ASP.NET Core, HttpClient (Google Places), and Npgsql spans all print to the console, correctly nested under one trace.
- [ ] After merge, confirm traces show up in Cloud Trace for the test environment.
