### PR TITLE
Enable CPU-always-allocated on Cloud Run so OTel spans actually export

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -115,6 +115,7 @@ jobs:
             --set-env-vars "^|^ASPNETCORE_ENVIRONMENT=Production|AllowedUsers__Enabled=${{ vars.ALLOWED_USERS_ENABLED }}|Serilog__WriteTo__0__Name=GoogleCloudLogging|Serilog__WriteTo__0__Args__projectId=${{ vars.GCP_PROJECT_ID }}|Serilog__WriteTo__0__Args__serviceName=tipical-api-prod|Serilog__WriteTo__0__Args__serviceVersion=${IMAGE_TAG}|OpenTelemetry__ServiceName=tipical-api-prod|OpenTelemetry__ServiceVersion=${IMAGE_TAG}|OpenTelemetry__Otlp__Endpoint=https://telemetry.googleapis.com/v1/traces" \
             --service-account tipical-api-prod@${{ vars.GCP_PROJECT_ID }}.iam.gserviceaccount.com \
             --allow-unauthenticated \
+            --no-cpu-throttling \
             --quiet
 
           URL=$(gcloud run services describe tipical-api-prod \

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -109,6 +109,7 @@ jobs:
             --set-env-vars "^|^ASPNETCORE_ENVIRONMENT=Production|AllowedUsers__Enabled=${{ vars.ALLOWED_USERS_ENABLED }}|Serilog__WriteTo__0__Name=GoogleCloudLogging|Serilog__WriteTo__0__Args__projectId=${{ vars.GCP_PROJECT_ID }}|Serilog__WriteTo__0__Args__serviceName=tipical-api-test|Serilog__WriteTo__0__Args__serviceVersion=${{ github.sha }}|OpenTelemetry__ServiceName=tipical-api-test|OpenTelemetry__ServiceVersion=${{ github.sha }}|OpenTelemetry__Otlp__Endpoint=https://telemetry.googleapis.com/v1/traces" \
             --service-account tipical-api-test@${{ vars.GCP_PROJECT_ID }}.iam.gserviceaccount.com \
             --allow-unauthenticated \
+            --no-cpu-throttling \
             --quiet
 
           URL=$(gcloud run services describe tipical-api-test \


### PR DESCRIPTION
## Summary

The OpenTelemetry tracing added in #220 was silently dropping spans in deployed environments. Cloud Run only allocates CPU to a container while it's actively handling a request; outside of that it throttles CPU to near-zero. OpenTelemetry's default batch span processor buffers finished spans and flushes them on a background timer (~every 5s) — that timer never gets scheduled once the instance is throttled right after the response completes, so buffered spans (our ASP.NET Core root span, HttpClient span, Npgsql span) were dropped before ever reaching Cloud Trace.

Confirmed via Trace Explorer: a real trace from `tipical-api-test` showed only Cloud Run's own built-in platform-level span, with a `(Missing span ID ...)` placeholder where our app's root span should have been — its data was created but never exported.

- Adds `--no-cpu-throttling` to the `gcloud run deploy` commands in both `deploy-test.yml` and `deploy-prod.yml`, so CPU stays available between requests and the batch processor's background flush can actually run.
- This is independent of scale-to-zero/min-instances — the service can still scale to zero after Cloud Run's normal idle timeout (~15 min after last request unless min-instances is set). Cost changes from per-request billing to instance-lifetime billing while a container is warm (CPU/memory rates are also lower per unit under this mode).

## Note

`tipical-api-test` was already updated live via `gcloud run services update --no-cpu-throttling` to validate the fix before this PR merges — see test plan below. `tipical-api-prod` has not been touched; it'll pick up `--no-cpu-throttling` on the next prod deploy after this merges.

## Test plan

- [x] Applied `--no-cpu-throttling` to the live `tipical-api-test` service.
- [ ] Generate a fresh request against test and confirm the full span tree (not just Cloud Run's native span) shows up in Trace Explorer, with no missing-span placeholder.
