### PR TITLE
Enrich Serilog request logs with route template

### DIFF
--- a/tipical-backend/src/Tipical.Api/Program.cs
+++ b/tipical-backend/src/Tipical.Api/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.AspNetCore.Routing;
 using Tipical.Api;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
@@ -184,7 +185,19 @@ if (app.Environment.IsDevelopment())
 
 // Emit a single structured log entry per HTTP request (method, path, status,
 // elapsed time) instead of the framework's noisy multi-line default.
-app.UseSerilogRequestLogging();
+app.UseSerilogRequestLogging(options =>
+{
+    // Attach the matched route template (e.g. "api/venues/{id}") alongside the
+    // raw request path, so logs can be grouped/aggregated by endpoint instead
+    // of fragmenting by every distinct path segment value.
+    options.EnrichDiagnosticContext = (diagnosticContext, httpContext) =>
+    {
+        if (httpContext.GetEndpoint() is RouteEndpoint routeEndpoint)
+        {
+            diagnosticContext.Set("RouteTemplate", routeEndpoint.RoutePattern.RawText);
+        }
+    };
+});
 
 // Global exception handling
 app.UseExceptionHandler(errorApp =>


### PR DESCRIPTION
## Summary
- `UseSerilogRequestLogging()` now sets an `EnrichDiagnosticContext` callback that reads the matched `RouteEndpoint` and attaches its route template (e.g. `api/venues/{id}`) as a structured `RouteTemplate` property on each request-completion log line, alongside the existing raw `RequestPath`.
- Endpoint selection happens before this middleware runs, so `HttpContext.GetEndpoint()` is already populated at this point.

Fixes #222

## Test plan
- [x] `dotnet build` succeeds
- [x] Manually verified locally against `docker compose`: hit `GET /api/v1/businesses/test123/details`, and the request-completion log line included `"RouteTemplate": "api/v1/businesses/{googlePlaceId}/details"` alongside the raw path
