### PR TITLE
Fix Cloud Trace OTLP export: override sync Send(), add gcp.project_id

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -112,7 +112,7 @@ jobs:
             --region ${{ env.REGION }} \
             --add-cloudsql-instances ${{ vars.GCP_PROJECT_ID }}:${{ env.REGION }}:tipical-db-prod \
             --set-secrets "ConnectionStrings__DefaultConnection=prod-db-connection-string:latest,GooglePlaces__ApiKey=prod-google-places-api-key:latest,GoogleOAuth__ClientId=prod-google-oauth-client-id:latest,JwtSettings__Secret=prod-jwt-secret:latest" \
-            --set-env-vars "^|^ASPNETCORE_ENVIRONMENT=Production|AllowedUsers__Enabled=${{ vars.ALLOWED_USERS_ENABLED }}|Serilog__WriteTo__0__Name=GoogleCloudLogging|Serilog__WriteTo__0__Args__projectId=${{ vars.GCP_PROJECT_ID }}|Serilog__WriteTo__0__Args__serviceName=tipical-api-prod|Serilog__WriteTo__0__Args__serviceVersion=${IMAGE_TAG}|OpenTelemetry__ServiceName=tipical-api-prod|OpenTelemetry__ServiceVersion=${IMAGE_TAG}|OpenTelemetry__Otlp__Endpoint=https://telemetry.googleapis.com/v1/traces" \
+            --set-env-vars "^|^ASPNETCORE_ENVIRONMENT=Production|AllowedUsers__Enabled=${{ vars.ALLOWED_USERS_ENABLED }}|Serilog__WriteTo__0__Name=GoogleCloudLogging|Serilog__WriteTo__0__Args__projectId=${{ vars.GCP_PROJECT_ID }}|Serilog__WriteTo__0__Args__serviceName=tipical-api-prod|Serilog__WriteTo__0__Args__serviceVersion=${IMAGE_TAG}|OpenTelemetry__ServiceName=tipical-api-prod|OpenTelemetry__ServiceVersion=${IMAGE_TAG}|OpenTelemetry__GcpProjectId=${{ vars.GCP_PROJECT_ID }}|OpenTelemetry__Otlp__Endpoint=https://telemetry.googleapis.com/v1/traces" \
             --service-account tipical-api-prod@${{ vars.GCP_PROJECT_ID }}.iam.gserviceaccount.com \
             --allow-unauthenticated \
             --quiet

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -106,7 +106,7 @@ jobs:
             --region ${{ env.REGION }} \
             --add-cloudsql-instances ${{ vars.GCP_PROJECT_ID }}:${{ env.REGION }}:tipical-db-test \
             --set-secrets "ConnectionStrings__DefaultConnection=test-db-connection-string:latest,GooglePlaces__ApiKey=test-google-places-api-key:latest,GoogleOAuth__ClientId=test-google-oauth-client-id:latest,JwtSettings__Secret=test-jwt-secret:latest" \
-            --set-env-vars "^|^ASPNETCORE_ENVIRONMENT=Production|AllowedUsers__Enabled=${{ vars.ALLOWED_USERS_ENABLED }}|Serilog__WriteTo__0__Name=GoogleCloudLogging|Serilog__WriteTo__0__Args__projectId=${{ vars.GCP_PROJECT_ID }}|Serilog__WriteTo__0__Args__serviceName=tipical-api-test|Serilog__WriteTo__0__Args__serviceVersion=${{ github.sha }}|OpenTelemetry__ServiceName=tipical-api-test|OpenTelemetry__ServiceVersion=${{ github.sha }}|OpenTelemetry__Otlp__Endpoint=https://telemetry.googleapis.com/v1/traces" \
+            --set-env-vars "^|^ASPNETCORE_ENVIRONMENT=Production|AllowedUsers__Enabled=${{ vars.ALLOWED_USERS_ENABLED }}|Serilog__WriteTo__0__Name=GoogleCloudLogging|Serilog__WriteTo__0__Args__projectId=${{ vars.GCP_PROJECT_ID }}|Serilog__WriteTo__0__Args__serviceName=tipical-api-test|Serilog__WriteTo__0__Args__serviceVersion=${{ github.sha }}|OpenTelemetry__ServiceName=tipical-api-test|OpenTelemetry__ServiceVersion=${{ github.sha }}|OpenTelemetry__GcpProjectId=${{ vars.GCP_PROJECT_ID }}|OpenTelemetry__Otlp__Endpoint=https://telemetry.googleapis.com/v1/traces" \
             --service-account tipical-api-test@${{ vars.GCP_PROJECT_ID }}.iam.gserviceaccount.com \
             --allow-unauthenticated \
             --quiet

--- a/tipical-backend/src/Tipical.Api/GoogleCloudTraceHttpClient.cs
+++ b/tipical-backend/src/Tipical.Api/GoogleCloudTraceHttpClient.cs
@@ -17,10 +17,6 @@ internal static class GoogleCloudTraceHttpClient
 
     public static HttpClient Create() => new(new AuthenticatingHandler());
 
-    // The OTLP exporter sends requests synchronously via HttpClient.Send() rather than
-    // SendAsync() (its own export path is synchronous, so it avoids sync-over-async by
-    // using the real synchronous API) - overriding only SendAsync here means this
-    // handler is silently skipped, so both need to be overridden.
     private sealed class AuthenticatingHandler() : DelegatingHandler(new HttpClientHandler())
     {
         protected override async Task<HttpResponseMessage> SendAsync(
@@ -31,6 +27,7 @@ internal static class GoogleCloudTraceHttpClient
             return await base.SendAsync(request, cancellationToken);
         }
 
+        // The OTLP exporter sends requests via this synchronous method, not SendAsync.
         protected override HttpResponseMessage Send(
             HttpRequestMessage request, CancellationToken cancellationToken)
         {

--- a/tipical-backend/src/Tipical.Api/GoogleCloudTraceHttpClient.cs
+++ b/tipical-backend/src/Tipical.Api/GoogleCloudTraceHttpClient.cs
@@ -17,15 +17,32 @@ internal static class GoogleCloudTraceHttpClient
 
     public static HttpClient Create() => new(new AuthenticatingHandler());
 
+    // The OTLP exporter sends requests synchronously via HttpClient.Send() rather than
+    // SendAsync() (its own export path is synchronous, so it avoids sync-over-async by
+    // using the real synchronous API) - overriding only SendAsync here means this
+    // handler is silently skipped, so both need to be overridden.
     private sealed class AuthenticatingHandler() : DelegatingHandler(new HttpClientHandler())
     {
         protected override async Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            var credential = await Credential.Value;
-            var token = await ((ITokenAccess)credential).GetAccessTokenForRequestAsync(cancellationToken: cancellationToken);
+            var token = await GetAccessTokenAsync(cancellationToken);
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
             return await base.SendAsync(request, cancellationToken);
+        }
+
+        protected override HttpResponseMessage Send(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var token = GetAccessTokenAsync(cancellationToken).GetAwaiter().GetResult();
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            return base.Send(request, cancellationToken);
+        }
+
+        private static async Task<string> GetAccessTokenAsync(CancellationToken cancellationToken)
+        {
+            var credential = await Credential.Value;
+            return await ((ITokenAccess)credential).GetAccessTokenForRequestAsync(cancellationToken: cancellationToken);
         }
     }
 }

--- a/tipical-backend/src/Tipical.Api/Program.cs
+++ b/tipical-backend/src/Tipical.Api/Program.cs
@@ -49,10 +49,10 @@ builder.Services.AddOpenTelemetry()
             serviceName: builder.Configuration["OpenTelemetry:ServiceName"] ?? "tipical-api",
             serviceVersion: builder.Configuration["OpenTelemetry:ServiceVersion"]);
 
-        // Cloud Trace's OTLP endpoint requires this to attribute traces to a project.
-        var gcpProjectId = builder.Configuration["OpenTelemetry:GcpProjectId"];
-        if (!string.IsNullOrEmpty(gcpProjectId))
+        if (!string.IsNullOrEmpty(otlpEndpoint))
         {
+            var gcpProjectId = builder.Configuration["OpenTelemetry:GcpProjectId"]
+                ?? throw new InvalidOperationException("GCP project ID not configured");
             resource.AddAttributes([new KeyValuePair<string, object>("gcp.project_id", gcpProjectId)]);
         }
     })

--- a/tipical-backend/src/Tipical.Api/Program.cs
+++ b/tipical-backend/src/Tipical.Api/Program.cs
@@ -1,6 +1,5 @@
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.RateLimiting;
-using Microsoft.AspNetCore.Routing;
 using Tipical.Api;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
@@ -44,9 +43,19 @@ builder.Services.AddSerilog((services, loggerConfiguration) => loggerConfigurati
 // the deployed Production environment (see OpenTelemetry:Otlp:Endpoint in appsettings).
 var otlpEndpoint = builder.Configuration["OpenTelemetry:Otlp:Endpoint"];
 builder.Services.AddOpenTelemetry()
-    .ConfigureResource(resource => resource.AddService(
-        serviceName: builder.Configuration["OpenTelemetry:ServiceName"] ?? "tipical-api",
-        serviceVersion: builder.Configuration["OpenTelemetry:ServiceVersion"]))
+    .ConfigureResource(resource =>
+    {
+        resource.AddService(
+            serviceName: builder.Configuration["OpenTelemetry:ServiceName"] ?? "tipical-api",
+            serviceVersion: builder.Configuration["OpenTelemetry:ServiceVersion"]);
+
+        // Cloud Trace's OTLP endpoint requires this to attribute traces to a project.
+        var gcpProjectId = builder.Configuration["OpenTelemetry:GcpProjectId"];
+        if (!string.IsNullOrEmpty(gcpProjectId))
+        {
+            resource.AddAttributes([new KeyValuePair<string, object>("gcp.project_id", gcpProjectId)]);
+        }
+    })
     .WithTracing(tracing =>
     {
         tracing.AddAspNetCoreInstrumentation()


### PR DESCRIPTION
## Summary

Traces added in #220 were never actually reaching Cloud Trace, even though the app ran fine with no visible errors. Root cause turned out to be two separate bugs, both fixed here.

**1. The OTLP exporter uses `HttpClient.Send()`, not `SendAsync()`.** Our `GoogleCloudTraceHttpClient.AuthenticatingHandler` only overrode `SendAsync`, so on the exporter's actual (synchronous) send path our handler was silently skipped entirely — every export request went out with no `Authorization` header, and Cloud Trace rejected it with `403 Method doesn't allow unregistered callers`. Filed [open-telemetry/opentelemetry-dotnet#7575](https://github.com/open-telemetry/opentelemetry-dotnet/issues/7575) while tracking this down; a maintainer confirmed the cause and the fix (override `Send()` too, not just `SendAsync()`).

**2. Cloud Trace's OTLP endpoint requires a `gcp.project_id` resource attribute.** Once auth was fixed, exports started failing with `400 Resource is missing required attribute "gcp.project_id"`. Added it via a new `OpenTelemetry:GcpProjectId` config key, set by the deploy workflows the same way `GCP_PROJECT_ID` already is for the Serilog Google Cloud Logging sink.

## Test plan

- [x] Ran locally against the real Cloud Trace OTLP endpoint (`https://telemetry.googleapis.com/v1/traces`), using real `gcloud` user credentials via Application Default Credentials.
- [x] Confirmed via OpenTelemetry's own internal diagnostics (a temporary `EventListener`, not included in this PR) that exports now report `ExportSuccess` with zero errors — previously this reliably reproduced `403`, then `400`, on every export.
- [ ] After merge + deploy, confirm traces show up in Trace Explorer for the test environment with the full span tree (not just Cloud Run's own native span).
