### PR TITLE
Add gRPC client instrumentation to capture Google Places API spans

### DIFF
--- a/tipical-backend/Directory.Packages.props
+++ b/tipical-backend/Directory.Packages.props
@@ -22,6 +22,7 @@
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.17.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageVersion Include="Serilog.Enrichers.Environment" Version="3.0.1" />

--- a/tipical-backend/src/Tipical.Api/Program.cs
+++ b/tipical-backend/src/Tipical.Api/Program.cs
@@ -59,6 +59,7 @@ builder.Services.AddOpenTelemetry()
     .WithTracing(tracing =>
     {
         tracing.AddAspNetCoreInstrumentation()
+            .AddGrpcClientInstrumentation()
             .AddHttpClientInstrumentation()
             .AddNpgsql();
 

--- a/tipical-backend/src/Tipical.Api/Tipical.Api.csproj
+++ b/tipical-backend/src/Tipical.Api/Tipical.Api.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
     <PackageReference Include="Serilog.AspNetCore" />
     <PackageReference Include="Serilog.Enrichers.Environment" />


### PR DESCRIPTION
## Summary

- Registers `.AddGrpcClientInstrumentation()` in the OpenTelemetry tracing setup so gRPC calls made by the Google Places API client (`Grpc.Net.Client`) are recorded and exported as proper spans, instead of leaving the underlying HTTP span's parent as an unexported `(Missing span ID ...)` placeholder in Cloud Trace.
- Adds the `OpenTelemetry.Instrumentation.GrpcNetClient` package (1.17.0-beta.1, matching the other 1.17.0-line OTel packages already in use; this package is still beta upstream).

Fixes #225

## Test plan

- [x] `dotnet build` succeeds
- [ ] Deploy and confirm Places API calls (search, place details, photos) now appear as named spans nested correctly under their parent request span in Cloud Trace, with no new `(Missing span ID ...)` entries for those calls
