### PR TITLE
Force-flush OpenTelemetry traces per request to fix dropped spans

### DIFF
--- a/tipical-backend/src/Tipical.Api/Program.cs
+++ b/tipical-backend/src/Tipical.Api/Program.cs
@@ -209,6 +209,21 @@ app.UseSerilogRequestLogging(options =>
     };
 });
 
+// TODO: deprecate as part of #227
+var tracerProvider = app.Services.GetRequiredService<TracerProvider>();
+app.Use(async (context, next) =>
+{
+    await next(context);
+    try
+    {
+        await Task.Run(() => tracerProvider.ForceFlush(5000));
+    }
+    catch (Exception ex)
+    {
+        app.Logger.LogWarning(ex, "Failed to force-flush OpenTelemetry traces");
+    }
+});
+
 // Global exception handling
 app.UseExceptionHandler(errorApp =>
 {


### PR DESCRIPTION
## Summary
- Traces were being silently dropped for requests handled in quick succession alongside other requests, because Cloud Run's CPU throttling starves the OTLP exporter's background batch timer under concurrent load.
- Adds middleware in `Program.cs` that force-flushes the tracer provider synchronously after every request, giving export a guaranteed CPU window instead of depending on the background timer.

## Tradeoffs
- Adds a Cloud Trace export round-trip to every request's latency.
- Not a complete fix under sustained heavy concurrency — the real fix (OTel Collector sidecar with a persistent retry queue) is tracked in #227 and should replace this once implemented.

## Test plan
- [x] `dotnet build` passes
- [ ] Deploy to test env and confirm traces for concurrent/bursty requests (e.g. rapid business detail views) now show up in Cloud Trace

Closes nothing directly; tracked follow-up: #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)
