### PR TITLE
Replace force-flush middleware with Simple export processor

### DIFF
--- a/tipical-backend/src/Tipical.Api/Program.cs
+++ b/tipical-backend/src/Tipical.Api/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi;
 using Npgsql;
+using OpenTelemetry;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
@@ -74,6 +75,8 @@ builder.Services.AddOpenTelemetry()
                 otlp.Protocol = OtlpExportProtocol.HttpProtobuf;
                 otlp.Endpoint = new Uri(otlpEndpoint);
                 otlp.HttpClientFactory = GoogleCloudTraceHttpClient.Create;
+                // TODO: deprecate as part of #227 (see Simple vs Batch tradeoff there)
+                otlp.ExportProcessorType = ExportProcessorType.Simple;
             });
         }
     });
@@ -207,21 +210,6 @@ app.UseSerilogRequestLogging(options =>
             diagnosticContext.Set("RouteTemplate", routeEndpoint.RoutePattern.RawText);
         }
     };
-});
-
-// TODO: deprecate as part of #227
-var tracerProvider = app.Services.GetRequiredService<TracerProvider>();
-app.Use(async (context, next) =>
-{
-    await next(context);
-    try
-    {
-        await Task.Run(() => tracerProvider.ForceFlush(5000));
-    }
-    catch (Exception ex)
-    {
-        app.Logger.LogWarning(ex, "Failed to force-flush OpenTelemetry traces");
-    }
 });
 
 // Global exception handling


### PR DESCRIPTION
## Summary
- The force-flush middleware from #228 didn't actually fix the dropped-traces issue — confirmed in prod with a pair of consecutive `/details` requests, both still missing from Cloud Trace.
- Root cause of *that* fix's failure: it called `ForceFlush()` right after `await next(context)`, but ASP.NET Core doesn't stop a request's `Activity` (which is what hands the span off to the exporter) until after the entire middleware pipeline returns control to the hosting layer — structurally after our own flush call. It could only ever catch a previous request's span, and even that wasn't reliable.
- Replaces it with `OtlpExporterOptions.ExportProcessorType = ExportProcessorType.Simple`, a built-in SDK option that exports each span synchronously the instant its `Activity` stops — inside the same call stack Cloud Run is still awaiting, so CPU is guaranteed to be allocated for the export.

## Tradeoffs
- Simple processor sends one HTTP call per span instead of one batched call per request, so higher-fanout endpoints (e.g. `/search`, ~15 spans) now make more OTLP calls per request than before.
- Still not a long-term fix — tracked in #227, which will replace this with an OTel Collector sidecar that batches and retries independently of request timing.

## Test plan
- [x] `dotnet build` passes
- [ ] Deploy to test env and confirm traces for `/details` and `/votes` requests fired back-to-back now appear in Cloud Trace

🤖 Generated with [Claude Code](https://claude.com/claude-code)
