### PR TITLE
Temporarily log raw OTLP export responses to Cloud Trace

### DIFF
--- a/tipical-backend/src/Tipical.Api/GoogleCloudTraceHttpClient.cs
+++ b/tipical-backend/src/Tipical.Api/GoogleCloudTraceHttpClient.cs
@@ -24,7 +24,9 @@ internal static class GoogleCloudTraceHttpClient
         {
             var token = await GetAccessTokenAsync(cancellationToken);
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            return await base.SendAsync(request, cancellationToken);
+            var response = await base.SendAsync(request, cancellationToken);
+            await LogResponseAsync(response, cancellationToken);
+            return response;
         }
 
         // The OTLP exporter sends requests via this synchronous method, not SendAsync.
@@ -33,7 +35,25 @@ internal static class GoogleCloudTraceHttpClient
         {
             var token = GetAccessTokenAsync(cancellationToken).GetAwaiter().GetResult();
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            return base.Send(request, cancellationToken);
+            var response = base.Send(request, cancellationToken);
+            LogResponseAsync(response, cancellationToken).GetAwaiter().GetResult();
+            return response;
+        }
+
+        // TEMPORARY DIAGNOSTIC (#227): the OTel SDK swallows export failures with no
+        // visibility into app logs; this surfaces the raw Cloud Trace response to find
+        // out why spans still aren't showing up. Remove once resolved.
+        private static async Task LogResponseAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+        {
+            if (response.IsSuccessStatusCode)
+            {
+                Console.Error.WriteLine($"[OTLP export] {(int)response.StatusCode} {response.StatusCode}");
+            }
+            else
+            {
+                var body = await response.Content.ReadAsStringAsync(cancellationToken);
+                Console.Error.WriteLine($"[OTLP export] {(int)response.StatusCode} {response.StatusCode}: {body}");
+            }
         }
 
         private static async Task<string> GetAccessTokenAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary
- #229's `ExportProcessorType.Simple` fix still doesn't get spans into Cloud Trace in prod — confirmed with a fresh pair of consecutive `/details` traces still missing after that deploy.
- I verified via a standalone reflection test that `SimpleActivityExportProcessor` really is being constructed with this config, so the SDK-level config isn't the issue.
- Checked raw Cloud Run logs around the failing requests for any sign of an export attempt or failure — nothing. The OTel SDK swallows export exceptions/non-success responses internally with no visibility into our app logs.
- This is a diagnostic-only change: logs every OTLP export response's status code (and body on failure) directly from `GoogleCloudTraceHttpClient`, bypassing the SDK's internal self-diagnostics entirely, so we can see what's actually happening on the next test.

## Test plan
- [x] `dotnet build` passes
- [ ] Deploy to prod, reproduce with a rapid pair of `/details` (or similar) requests, and check Cloud Run logs for `[OTLP export]` lines to see whether exports are failing, succeeding-but-not-landing, or not being attempted at all

🤖 Generated with [Claude Code](https://claude.com/claude-code)
