### PR TITLE
Log OTLP export response body on success too

### DIFF
--- a/tipical-backend/src/Tipical.Api/GoogleCloudTraceHttpClient.cs
+++ b/tipical-backend/src/Tipical.Api/GoogleCloudTraceHttpClient.cs
@@ -45,15 +45,12 @@ internal static class GoogleCloudTraceHttpClient
         // out why spans still aren't showing up. Remove once resolved.
         private static async Task LogResponseAsync(HttpResponseMessage response, CancellationToken cancellationToken)
         {
-            if (response.IsSuccessStatusCode)
-            {
-                Console.Error.WriteLine($"[OTLP export] {(int)response.StatusCode} {response.StatusCode}");
-            }
-            else
-            {
-                var body = await response.Content.ReadAsStringAsync(cancellationToken);
-                Console.Error.WriteLine($"[OTLP export] {(int)response.StatusCode} {response.StatusCode}: {body}");
-            }
+            // OTLP allows a 200 response that still rejects some/all spans via a
+            // partial_success field in the (protobuf) body, so read it either way —
+            // status code alone isn't enough to tell whether the export landed.
+            var bytes = await response.Content.ReadAsByteArrayAsync(cancellationToken);
+            var raw = System.Text.Encoding.Latin1.GetString(bytes);
+            Console.Error.WriteLine($"[OTLP export] {(int)response.StatusCode} {response.StatusCode}, {bytes.Length} body bytes: {raw}");
         }
 
         private static async Task<string> GetAccessTokenAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary
- After deploying #230's diagnostic, all `[OTLP export]` logs show `200 OK` — but cross-checking against the Cloud Trace API directly, 6 of 7 traces from the same export burst are still missing (only one `/search` trace, with 7 spans, actually landed).
- HTTP transport succeeding while data doesn't land is a known OTLP pattern: the server can return 200 while rejecting some/all spans via a `partial_success` field in the response body. We were only reading the body on non-2xx responses, so we've had no visibility into this.
- Reads and logs the raw response body on every export response, not just failures.

Part of the ongoing investigation tracked in #227.

## Test plan
- [x] `dotnet build` passes
- [ ] Deploy to prod, reproduce, and check `[OTLP export]` log lines for body content — looking for a `partial_success`/rejection message even on 200s

🤖 Generated with [Claude Code](https://claude.com/claude-code)
