### PR TITLE
Revert tracing workarounds from the dropped-spans investigation

### DIFF
--- a/tipical-backend/src/Tipical.Api/GoogleCloudTraceHttpClient.cs
+++ b/tipical-backend/src/Tipical.Api/GoogleCloudTraceHttpClient.cs
@@ -24,9 +24,7 @@ internal static class GoogleCloudTraceHttpClient
         {
             var token = await GetAccessTokenAsync(cancellationToken);
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            var response = await base.SendAsync(request, cancellationToken);
-            await LogResponseAsync(response, cancellationToken);
-            return response;
+            return await base.SendAsync(request, cancellationToken);
         }
 
         // The OTLP exporter sends requests via this synchronous method, not SendAsync.
@@ -35,22 +33,7 @@ internal static class GoogleCloudTraceHttpClient
         {
             var token = GetAccessTokenAsync(cancellationToken).GetAwaiter().GetResult();
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
-            var response = base.Send(request, cancellationToken);
-            LogResponseAsync(response, cancellationToken).GetAwaiter().GetResult();
-            return response;
-        }
-
-        // TEMPORARY DIAGNOSTIC (#227): the OTel SDK swallows export failures with no
-        // visibility into app logs; this surfaces the raw Cloud Trace response to find
-        // out why spans still aren't showing up. Remove once resolved.
-        private static async Task LogResponseAsync(HttpResponseMessage response, CancellationToken cancellationToken)
-        {
-            // OTLP allows a 200 response that still rejects some/all spans via a
-            // partial_success field in the (protobuf) body, so read it either way —
-            // status code alone isn't enough to tell whether the export landed.
-            var bytes = await response.Content.ReadAsByteArrayAsync(cancellationToken);
-            var raw = System.Text.Encoding.Latin1.GetString(bytes);
-            Console.Error.WriteLine($"[OTLP export] {(int)response.StatusCode} {response.StatusCode}, {bytes.Length} body bytes: {raw}");
+            return base.Send(request, cancellationToken);
         }
 
         private static async Task<string> GetAccessTokenAsync(CancellationToken cancellationToken)

--- a/tipical-backend/src/Tipical.Api/Program.cs
+++ b/tipical-backend/src/Tipical.Api/Program.cs
@@ -5,7 +5,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi;
 using Npgsql;
-using OpenTelemetry;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
@@ -75,8 +74,6 @@ builder.Services.AddOpenTelemetry()
                 otlp.Protocol = OtlpExportProtocol.HttpProtobuf;
                 otlp.Endpoint = new Uri(otlpEndpoint);
                 otlp.HttpClientFactory = GoogleCloudTraceHttpClient.Create;
-                // TODO: deprecate as part of #227 (see Simple vs Batch tradeoff there)
-                otlp.ExportProcessorType = ExportProcessorType.Simple;
             });
         }
     });


### PR DESCRIPTION
## Summary
- Reverts all tracing workarounds attempted while investigating dropped Cloud Trace spans (#228, #229, #230, #231), restoring `Program.cs` and `GoogleCloudTraceHttpClient.cs` to their exact state from just before #228.
- The investigation found the missing spans were expected Cloud Run platform behavior, not a bug — see the findings comment on #227 for details. No client-side export change could have fixed it, which is why none of the attempted workarounds actually resolved the symptom.

## Test plan
- [x] `dotnet build` passes
- [x] Diffed against the pre-#228 commit to confirm an exact revert

Closes #227
